### PR TITLE
feat: Add canary word support

### DIFF
--- a/src/banks/config.py
+++ b/src/banks/config.py
@@ -1,0 +1,6 @@
+import os
+
+from .utils import strtobool
+
+
+async_enabled = strtobool(os.environ.get("BANKS_ASYNC_ENABLED", "false"))

--- a/src/banks/errors.py
+++ b/src/banks/errors.py
@@ -7,3 +7,7 @@ class MissingDependencyError(Exception):
 
 class AsyncError(Exception):
     pass
+
+
+class CanaryWordError(Exception):
+    pass

--- a/src/banks/prompt.py
+++ b/src/banks/prompt.py
@@ -3,13 +3,24 @@
 # SPDX-License-Identifier: MIT
 from typing import Optional
 
-from banks.env import async_enabled, env
-from banks.errors import AsyncError
+from .env import env
+from .config import async_enabled
+from .errors import AsyncError
+from .utils import generate_canary_word
 
 
 class BasePrompt:
-    def __init__(self, text: str) -> None:
+    def __init__(self, text: str, canary_word: Optional[str] = None) -> None:
         self._template = env.from_string(text)
+        self.defaults = {"canary_word": canary_word or generate_canary_word()}
+
+    def _get_context(self, data: Optional[dict]) -> dict:
+        if data is None:
+            return self.defaults
+        return data | self.defaults
+
+    def canary_leaked(self, text: str) -> bool:
+        return self.defaults["canary_word"] in text
 
     @classmethod
     def from_template(cls, name: str) -> "BasePrompt":
@@ -20,7 +31,7 @@ class BasePrompt:
 
 class Prompt(BasePrompt):
     def text(self, data: Optional[dict] = None) -> str:
-        data = data or {}
+        data = self._get_context(data)
         return self._template.render(data)
 
 
@@ -33,6 +44,6 @@ class AsyncPrompt(BasePrompt):
             raise AsyncError(msg)
 
     async def text(self, data: Optional[dict] = None) -> str:
-        data = data or {}
+        data = self._get_context(data)
         result: str = await self._template.render_async(data)
         return result

--- a/src/banks/utils.py
+++ b/src/banks/utils.py
@@ -1,0 +1,23 @@
+import secrets
+
+
+def strtobool(val: str) -> bool:
+    """
+    Convert a string representation of truth to True or False.
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+    """
+    val = val.lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return True
+    elif val in ("n", "no", "f", "false", "off", "0"):
+        return False
+    else:
+        msg = f"invalid truth value {val}"
+        raise ValueError(msg)
+
+
+def generate_canary_word(prefix: str = "BANKS[", suffix: str = "]", token_length: int = 8) -> str:
+    return f"{prefix}{secrets.token_hex(token_length // 2)}{suffix}"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,8 @@
 # SPDX-FileCopyrightText: 2023-present Massimiliano Pippi <mpippi@gmail.com>
 #
 # SPDX-License-Identifier: MIT
+import warnings
+
+# banks depends on modules producing loads of deprecation warnings, let's just ignore them,
+# nothing we can do anyways
+warnings.simplefilter("ignore", category=DeprecationWarning)

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,0 +1,16 @@
+import regex as re
+
+from banks import Prompt
+
+
+def test_canary_word_generation():
+    p = Prompt("{{canary_word}}This is my prompt")
+    assert re.match(r"BANKS\[.{8}\]This is my prompt", p.text())
+
+
+def test_canary_word_leaked():
+    p = Prompt("{{canary_word}}This is my prompt")
+    assert p.canary_leaked(p.text())
+
+    p = Prompt("This is my prompt")
+    assert not p.canary_leaked(p.text())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,48 @@
+import regex as re
+
+import pytest
+
+from banks.utils import generate_canary_word, strtobool
+
+
+def test_generate_canary_word_defaults():
+    default = generate_canary_word()
+    assert re.match(r"BANKS\[.{8}\]", default)
+
+
+def test_generate_canary_word_params():
+    only_token = generate_canary_word(prefix="", suffix="", token_length=16)
+    assert re.match(r".{16}", only_token)
+
+    only_prefix = generate_canary_word(prefix="foo", suffix="")
+    assert re.match(r"foo.{8}", only_prefix)
+
+    only_suffix = generate_canary_word(prefix="", suffix="foo")
+    assert re.match(r".{8}foo", only_suffix)
+
+
+def test_strtobool_error():
+    with pytest.raises(ValueError):
+        strtobool("42")
+
+
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        ("y", True),
+        ("yes", True),
+        ("t", True),
+        ("true", True),
+        ("on", True),
+        ("1", True),
+        ("n", False),
+        ("no", False),
+        ("f", False),
+        ("false", False),
+        ("off", False),
+        ("0", False),
+        pytest.param("42", True, marks=pytest.mark.xfail),
+    ],
+)
+def test_strtobool(test_input, expected):
+    assert strtobool(test_input) == expected


### PR DESCRIPTION
Usage
```py
SYSTEM_PROMPT = Prompt("{{canary_word}} You are a helpful assistant.")

# somewhere in your app, `generate` uses SYSTEM_PROMPT
output = generate("This is a prompt injection attempt")

# check the system prompt hasn't leaked
assert not SYSTEM_PROMPT.canary_leaked(output)
```