### PR TITLE
feat: cache prompt rendering

### DIFF
--- a/src/banks/__init__.py
+++ b/src/banks/__init__.py
@@ -1,11 +1,13 @@
 # SPDX-FileCopyrightText: 2023-present Massimiliano Pippi <mpippi@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-from banks.env import env
-from banks.prompt import AsyncPrompt, Prompt
+from .cache import RenderCache
+from .env import env
+from .prompt import AsyncPrompt, Prompt
 
 __all__ = (
     "env",
     "Prompt",
     "AsyncPrompt",
+    "RenderCache",
 )

--- a/src/banks/cache.py
+++ b/src/banks/cache.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2023-present Massimiliano Pippi <mpippi@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+import pickle
+from typing import Optional, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class RenderCache(Protocol):
+    def get(self, context: dict) -> Optional[str]: ...
+
+    def set(self, context: dict, prompt: str) -> None: ...
+
+    def clear(self) -> None: ...
+
+
+class DefaultCache:
+    def __init__(self) -> None:
+        self._cache: dict[bytes, str] = {}
+
+    def get(self, context: dict) -> Optional[str]:
+        return self._cache.get(pickle.dumps(context, pickle.HIGHEST_PROTOCOL))
+
+    def set(self, context: dict, prompt: str) -> None:
+        self._cache[pickle.dumps(context, pickle.HIGHEST_PROTOCOL)] = prompt
+
+    def clear(self) -> None:
+        self._cache = {}

--- a/src/banks/prompt.py
+++ b/src/banks/prompt.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 import pickle
-from typing import Any, Optional
+from typing import Optional
 
 from .config import async_enabled
 from .env import env

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,30 @@
+import pytest
+
+from banks.cache import DefaultCache
+
+
+@pytest.fixture
+def cache():
+    return DefaultCache()
+
+
+@pytest.mark.parametrize(
+    "context_value",
+    [{}, {"foo": "bar"}],
+)
+def test_default_cache_set(context_value, cache):
+    cache.set(context_value, "My prompt")
+    assert len(cache._cache) == 1
+    assert next(iter(cache._cache.values())) == "My prompt"
+
+
+def test_default_cache_get(cache):
+    cache.set({"foo": "bar"}, "My prompt")
+    assert cache.get({"foo": "bar"}) == "My prompt"
+    assert cache.get({"bar"}) is None
+
+
+def test_default_cache_clear(cache):
+    cache.set({"foo": "bar"}, "My prompt")
+    cache.clear()
+    assert not len(cache._cache)

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -3,6 +3,7 @@ from unittest import mock
 import regex as re
 
 from banks import Prompt
+from banks.cache import DefaultCache
 
 
 def test_canary_word_generation():
@@ -18,20 +19,9 @@ def test_canary_word_leaked():
     assert not p.canary_leaked(p.text())
 
 
-def test_prompt_cache_miss():
-    p = Prompt("This is my prompt")
+def test_prompt_cache():
+    mock_cache = DefaultCache()
+    mock_cache.set = mock.Mock()
+    p = Prompt("This is my prompt", render_cache=mock_cache)
     p.text()
-    cached = list(p._cache.values())
-    assert len(cached) == 1
-    assert cached[0] == "This is my prompt"
-
-
-def test_prompt_cache_hit():
-    p = Prompt("This is my prompt")
-    mock_render = mock.MagicMock()
-    p._template.render = mock_render
-    p.text()
-    mock_render.assert_called_once()
-    mock_render.reset_mock()
-    p.text()
-    mock_render.assert_not_called()
+    mock_cache.set.assert_called_once()

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,4 +1,5 @@
 import regex as re
+from unittest import mock
 
 from banks import Prompt
 
@@ -14,3 +15,22 @@ def test_canary_word_leaked():
 
     p = Prompt("This is my prompt")
     assert not p.canary_leaked(p.text())
+
+
+def test_prompt_cache_miss():
+    p = Prompt("This is my prompt")
+    p.text()
+    cached = list(p._cache.values())
+    assert len(cached) == 1
+    assert cached[0] == "This is my prompt"
+
+
+def test_prompt_cache_hit():
+    p = Prompt("This is my prompt")
+    mock_render = mock.MagicMock()
+    p._template.render = mock_render
+    p.text()
+    mock_render.assert_called_once()
+    mock_render.reset_mock()
+    p.text()
+    mock_render.assert_not_called()

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,5 +1,6 @@
-import regex as re
 from unittest import mock
+
+import regex as re
 
 from banks import Prompt
 


### PR DESCRIPTION
Cache the prompt rendering and return it if the same context is passed to `text()`