### PR TITLE
feat: Add support for chat messages via custom tag `{% chat %}`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,8 @@ ignore = [
   "C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915",
   # Avoid conflicts with the formatter
   "ISC001",
+  # Magic numbers
+  "PLR2004",
 ]
 unfixable = [
   # Don't touch unused imports

--- a/src/banks/__init__.py
+++ b/src/banks/__init__.py
@@ -3,11 +3,6 @@
 # SPDX-License-Identifier: MIT
 from .config import config
 from .env import env
-from .prompt import AsyncPrompt, Prompt
+from .prompt import AsyncPrompt, ChatMessage, Prompt
 
-__all__ = (
-    "env",
-    "Prompt",
-    "AsyncPrompt",
-    "config",
-)
+__all__ = ("env", "Prompt", "AsyncPrompt", "config", "ChatMessage")

--- a/src/banks/env.py
+++ b/src/banks/env.py
@@ -13,9 +13,9 @@ def _add_extensions(_env):
 
     For example, we use banks to manage the system prompt in `GenerateExtension`
     """
+    from .extensions.chat import ChatMessage  # pylint: disable=import-outside-toplevel
     from .extensions.generate import GenerateExtension  # pylint: disable=import-outside-toplevel
     from .extensions.inference_endpoint import HFInferenceEndpointsExtension  # pylint: disable=import-outside-toplevel
-    from .extensions.chat import ChatMessage
 
     _env.add_extension(GenerateExtension)
     _env.add_extension(HFInferenceEndpointsExtension)

--- a/src/banks/env.py
+++ b/src/banks/env.py
@@ -15,9 +15,11 @@ def _add_extensions(_env):
     """
     from .extensions.generate import GenerateExtension  # pylint: disable=import-outside-toplevel
     from .extensions.inference_endpoint import HFInferenceEndpointsExtension  # pylint: disable=import-outside-toplevel
+    from .extensions.chat import ChatMessage
 
     _env.add_extension(GenerateExtension)
     _env.add_extension(HFInferenceEndpointsExtension)
+    _env.add_extension(ChatMessage)
 
 
 # Init the Jinja env

--- a/src/banks/extensions/chat.py
+++ b/src/banks/extensions/chat.py
@@ -1,23 +1,23 @@
 # SPDX-FileCopyrightText: 2023-present Massimiliano Pippi <mpippi@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-import html
-import os
+import json
 
-import requests
 from jinja2 import TemplateSyntaxError, nodes
 from jinja2.ext import Extension
-
 
 SUPPORTED_TYPES = ("system", "user")
 
 
 class ChatMessage(Extension):
     """
+    `chat` can be used to render prompt text as structured ChatMessage objects.
 
     Example:
         ```
-
+        {% chat role="system" %}
+        You are a helpful assistant.
+        {% endchat %}
         ```
     """
 
@@ -65,5 +65,4 @@ class ChatMessage(Extension):
         """
         Helper callback.
         """
-        print({"role": role, "content": caller()})
-        return caller()
+        return json.dumps({"role": role, "content": caller()})

--- a/src/banks/extensions/chat.py
+++ b/src/banks/extensions/chat.py
@@ -49,7 +49,8 @@ class ChatMessage(Extension):
             raise TemplateSyntaxError(error_msg, lineno)
 
         if attr_value.value not in SUPPORTED_TYPES:
-            msg = f"Unknown role type '{attr_value}', use one of ({",".join(SUPPORTED_TYPES)})"
+            types = ",".join(SUPPORTED_TYPES)
+            msg = f"Unknown role type '{attr_value}', use one of ({types})"
             raise TemplateSyntaxError(msg, lineno)
 
         # Pass the role name to the CallBlock node

--- a/src/banks/extensions/chat.py
+++ b/src/banks/extensions/chat.py
@@ -40,7 +40,7 @@ class ChatMessage(Extension):
         # Anything else is a parse error
         error_msg = f"Invalid syntax for chat attribute, got '{gathered}', expected role=\"value\""
         try:
-            attr_name, attr_assign, attr_value = gathered
+            attr_name, attr_assign, attr_value = gathered  # pylint: disable=unbalanced-tuple-unpacking
         except ValueError:
             raise TemplateSyntaxError(error_msg, lineno) from None
 

--- a/src/banks/extensions/chat.py
+++ b/src/banks/extensions/chat.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2023-present Massimiliano Pippi <mpippi@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+import html
+import os
+
+import requests
+from jinja2 import TemplateSyntaxError, nodes
+from jinja2.ext import Extension
+
+
+SUPPORTED_TYPES = ("system", "user")
+
+
+class ChatMessage(Extension):
+    """
+
+    Example:
+        ```
+
+        ```
+    """
+
+    # a set of names that trigger the extension.
+    tags = {"chat"}  # noqa
+
+    def parse(self, parser):
+        # We get the line number of the first token for error reporting
+        lineno = next(parser.stream).lineno
+
+        # Gather tokens up to the next block_end ('%}')
+        gathered = []
+        while parser.stream.current.type != "block_end":
+            gathered.append(next(parser.stream))
+
+        # If all has gone well, we will have one triplet of tokens:
+        #   (type='name, value='role'),
+        #   (type='assign', value='='),
+        #   (type='string', value='user'),
+        # Anything else is a parse error
+        error_msg = f"Invalid syntax for chat attribute, got '{gathered}', expected role=\"value\""
+        try:
+            attr_name, attr_assign, attr_value = gathered
+        except ValueError:
+            raise TemplateSyntaxError(error_msg, lineno) from None
+
+        # Validate tag attributes
+        if attr_name.value != "role" or attr_assign.value != "=":
+            raise TemplateSyntaxError(error_msg, lineno)
+
+        if attr_value.value not in SUPPORTED_TYPES:
+            msg = f"Unknown role type '{attr_value}', use one of ({",".join(SUPPORTED_TYPES)})"
+            raise TemplateSyntaxError(msg, lineno)
+
+        # Pass the role name to the CallBlock node
+        args: list[nodes.Expr] = [nodes.Const(attr_value.value)]
+
+        # Message body
+        body = parser.parse_statements(("name:endchat",), drop_needle=True)
+
+        # Build messages list
+        return nodes.CallBlock(self.call_method("_store_chat_messages", args), [], [], body).set_lineno(lineno)
+
+    def _store_chat_messages(self, role, caller):
+        """
+        Helper callback.
+        """
+        print({"role": role, "content": caller()})
+        return caller()

--- a/tests/templates/chat.jinja
+++ b/tests/templates/chat.jinja
@@ -1,0 +1,15 @@
+{% chat role="system" %}
+You are a helpful assistant.
+{% endchat %}
+
+{% chat role="user" %}
+Hello, how are you?
+{% endchat %}
+
+{% chat role="system" %}
+I'm doing well, thank you! How can I assist you today?
+{% endchat %}
+
+{% chat role="user" %}
+Can you explain quantum computing?
+{% endchat %}

--- a/tests/templates/chat.jinja
+++ b/tests/templates/chat.jinja
@@ -13,3 +13,5 @@ I'm doing well, thank you! How can I assist you today?
 {% chat role="user" %}
 Can you explain quantum computing?
 {% endchat %}
+
+Some random text.

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,0 +1,19 @@
+import pytest
+from jinja2 import TemplateSyntaxError
+
+from banks import Prompt
+
+
+def test_wrong_tag():
+    with pytest.raises(TemplateSyntaxError):
+        Prompt("{% chat %}{% endchat %}")
+
+
+def test_wrong_tag_params():
+    with pytest.raises(TemplateSyntaxError):
+        Prompt('{% chat foo="bar" %}{% endchat %}')
+
+
+def test_wrong_role_type():
+    with pytest.raises(TemplateSyntaxError):
+        Prompt('{% chat role="does not exist" %}{% endchat %}')

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -5,7 +5,7 @@ import pytest
 import regex as re
 from jinja2 import Environment
 
-from banks import AsyncPrompt, Prompt, ChatMessage
+from banks import AsyncPrompt, ChatMessage, Prompt
 from banks.cache import DefaultCache
 from banks.errors import AsyncError
 


### PR DESCRIPTION
Usage:
```
{% chat role="system" %}
You are a helpful assistant.
{% endchat %}

{% chat role="user" %}
Hello, how are you?
{% endchat %}
```

Output of `prompt.chat_messages()`:
```py
[
    ChatMessage(role="system", content="You are a helpful assistant.\n"),
    ChatMessage(role="user", content="Hello, how are you?\n"),
]
```