### PR TITLE
fix: return a single chat message instead of an empty list when template has no `{% chat %}` tags

### DIFF
--- a/src/banks/prompt.py
+++ b/src/banks/prompt.py
@@ -134,6 +134,12 @@ class Prompt(BasePrompt):
             except ValidationError:
                 # Ignore lines that are not a message
                 pass
+
+        if not messages:
+            # fallback, if there was no {% chat %} block in the template,
+            # put the text into a single user message
+            messages.append(ChatMessage(role="user", content=rendered))
+
         return messages
 
 

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -111,3 +111,9 @@ def test_chat_messages_cached():
     p = Prompt(p_file.read_text(), render_cache=mock_cache)
     p.chat_messages()
     mock_cache.set.assert_called_once()
+
+
+def test_chat_message_no_chat_tag():
+    text = "This is raw text"
+    p = Prompt(text=text)
+    assert p.chat_messages() == [ChatMessage(role="user", content=text)]


### PR DESCRIPTION
When no `{% chat %}` tag is present in the template, `Prompt.chat_messages()` returns an empty list.
With this PR instead, we return a single `user` message containing the rendered template for convenience.