### PR TITLE
feat: add completion extension

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -47,10 +47,10 @@ Some functionalities require additional dependencies that need to be installed m
 
 If you like to jump straight to the code:
 
-- See a showcase of basic examples [here](examples).
+- See a showcase of basic examples [here](examples.md).
 - Check out the Cookbooks:
-    - :blue_book: [Prompt caching with Anthropic](./cookbooks/Prompt_Caching_with_Anthropic.ipynb)
-    - :blue_book: [Prompt versioning](./cookbooks/Prompt_Versioning.ipynb)
+    - :blue_book: [Prompt caching with Anthropic](https://github.com/masci/banks/blob/main/cookbooks/Prompt_Caching_with_Anthropic.ipynb)
+    - :blue_book: [Prompt versioning](https://github.com/masci/banks/blob/main/cookbooks/Prompt_Versioning.ipynb)
 
 ## License
 

--- a/docs/prompt.md
+++ b/docs/prompt.md
@@ -40,14 +40,21 @@ provided by Jinja, Banks supports the following ones, specific for prompt engine
 Extensions are custom functions that can be used to add new tags to the template engine.
 Banks supports the following ones, specific for prompt engineering.
 
-::: banks.extensions.chat.chat
+::: banks.extensions.docs.chat
     options:
         show_root_full_path: false
         show_symbol_type_heading: false
         show_signature_annotations: false
         heading_level: 3
 
-::: banks.extensions.generate.generate
+::: banks.extensions.docs.completion
+    options:
+        show_root_full_path: false
+        show_symbol_type_heading: false
+        show_signature_annotations: false
+        heading_level: 3
+
+::: banks.extensions.docs.generate
     options:
         show_root_full_path: false
         show_symbol_type_heading: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,10 @@ parallel = true
 omit = [
   "src/banks/__about__.py",
   "tests/*",
+  "src/banks/extensions/docs.py",
+  # deprecated modules, to be removed
+  "src/banks/extensions/inference_endpoint.py",
+  "src/banks/extensions/generate.py",
 ]
 
 [tool.coverage.paths]

--- a/src/banks/env.py
+++ b/src/banks/env.py
@@ -14,12 +14,14 @@ def _add_extensions(_env):
     For example, we use banks to manage the system prompt in `GenerateExtension`
     """
     from .extensions.chat import ChatExtension  # pylint: disable=import-outside-toplevel
+    from .extensions.completion import CompletionExtension  # pylint: disable=import-outside-toplevel
     from .extensions.generate import GenerateExtension  # pylint: disable=import-outside-toplevel
     from .extensions.inference_endpoint import HFInferenceEndpointsExtension  # pylint: disable=import-outside-toplevel
 
+    _env.add_extension(ChatExtension)
+    _env.add_extension(CompletionExtension)
     _env.add_extension(GenerateExtension)
     _env.add_extension(HFInferenceEndpointsExtension)
-    _env.add_extension(ChatExtension)
 
 
 # Init the Jinja env

--- a/src/banks/extensions/chat.py
+++ b/src/banks/extensions/chat.py
@@ -11,25 +11,6 @@ from banks.types import ChatMessage, ChatMessageContent, ContentBlock, ContentBl
 SUPPORTED_TYPES = ("system", "user")
 
 
-# This function exists for documentation purpose.
-def chat(role: str):  # pylint: disable=W0613
-    """
-    Text inside `chat` tags will be rendered as JSON strings representing chat messages. Calling `Prompt.chat_messages`
-    will return a list of `ChatMessage` instances.
-
-    Example:
-        ```jinja
-        {% chat role="system" %}
-        You are a helpful assistant.
-        {% endchat %}
-
-        {% chat role="user" %}
-        Hello, how are you?
-        {% endchat %}
-        ```
-    """
-
-
 class _ContentBlockParser(HTMLParser):
     """A parser used to extract text surrounded by `<content_block_txt>` and `</content_block_txt>` tags."""
 

--- a/src/banks/extensions/completion.py
+++ b/src/banks/extensions/completion.py
@@ -30,7 +30,7 @@ class CompletionExtension(Extension):
         {% endset %}
 
         {# output the response content #}
-        {{ response.choices[0].message.content }}
+        {{ response }}
         ```
     """
 

--- a/src/banks/extensions/completion.py
+++ b/src/banks/extensions/completion.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: 2023-present Massimiliano Pippi <mpippi@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from typing import cast
+
+from jinja2 import TemplateSyntaxError, nodes
+from jinja2.ext import Extension
+from litellm import acompletion, completion
+from litellm.types.utils import ModelResponse
+from pydantic import ValidationError
+
+from banks.types import ChatMessage
+
+SUPPORTED_KWARGS = ("model",)
+
+
+class CompletionExtension(Extension):
+    """
+    `completion` can be used to send to the LLM the content of the block in form of messages.
+
+    The rendered value of the block can be used as is but it's usually more useful to
+    assign it to a variable and access it from another section of the prompt.
+
+    Example:
+        ```
+        {% set response %}
+        {% completion model="gpt-3.5-turbo-0125" %}
+        {% chat role="user" %}You are a helpful assistant{% endchat %}
+        {% endcompletion %}
+        {% endset %}
+
+        {# output the response content #}
+        {{ response.choices[0].message.content }}
+        ```
+    """
+
+    # a set of names that trigger the extension.
+    tags = {"completion"}  # noqa
+
+    def parse(self, parser):
+        # We get the line number of the first token for error reporting
+        lineno = next(parser.stream).lineno
+
+        # Gather tokens up to the next block_end ('%}')
+        gathered = []
+        while parser.stream.current.type != "block_end":
+            gathered.append(next(parser.stream))
+
+        # If all has gone well, we will have one triplet of tokens:
+        #   (type='name', value='model'),
+        #   (type='assign', value='='),
+        #   (type='string', value='gpt-3.5-turbo-0125'),
+        # Anything else is a parse error
+        error_msg = f"Invalid syntax for completion: {gathered}"
+        try:
+            attr_name, attr_assign, attr_value = gathered  # pylint: disable=unbalanced-tuple-unpacking
+        except ValueError:
+            raise TemplateSyntaxError(error_msg, lineno) from None
+
+        # Validate tag attributes
+        if attr_name.value not in SUPPORTED_KWARGS or attr_assign.value != "=":
+            raise TemplateSyntaxError(error_msg, lineno)
+
+        # Pass the role name to the CallBlock node
+        args: list[nodes.Expr] = [nodes.Const(attr_value.value)]
+
+        # Message body
+        body = parser.parse_statements(("name:endcompletion",), drop_needle=True)
+
+        # Call LLM
+        if parser.environment.is_async:
+            return nodes.CallBlock(self.call_method("_do_completion_async", args), [], [], body).set_lineno(lineno)
+        return nodes.CallBlock(self.call_method("_do_completion", args), [], [], body).set_lineno(lineno)
+
+    def _do_completion(self, model_name, caller):
+        """
+        Helper callback.
+        """
+        messages = self._body_to_messages(caller())
+        if not messages:
+            return ""
+
+        response = cast(ModelResponse, completion(model=model_name, messages=messages))
+        return response.choices[0].message.content  # type: ignore
+
+    async def _do_completion_async(self, model_name, caller):
+        """
+        Helper callback.
+        """
+        messages = self._body_to_messages(caller())
+        if not messages:
+            return ""
+
+        response = cast(ModelResponse, await acompletion(model=model_name, messages=messages))
+        return response.choices[0].message.content  # type: ignore
+
+    def _body_to_messages(self, body: str) -> list[ChatMessage]:
+        body = body.strip()
+        if not body:
+            return []
+
+        messages = []
+        for line in body.split("\n"):
+            try:
+                messages.append(ChatMessage.model_validate_json(line))
+            except ValidationError:
+                # Ignore lines that are not a message
+                pass
+
+        if not messages:
+            messages.append(ChatMessage(role="user", content=body))
+
+        return messages

--- a/src/banks/extensions/completion.py
+++ b/src/banks/extensions/completion.py
@@ -103,8 +103,7 @@ class CompletionExtension(Extension):
         for line in body.split("\n"):
             try:
                 messages.append(ChatMessage.model_validate_json(line))
-            except ValidationError:
-                # Ignore lines that are not a message
+            except ValidationError:  # pylint: disable=R0801
                 pass
 
         if not messages:

--- a/src/banks/extensions/docs.py
+++ b/src/banks/extensions/docs.py
@@ -1,0 +1,52 @@
+# This module exists for documentation purpose only
+
+
+def chat(role: str):  # pylint: disable=W0613
+    """
+    Text inside `chat` tags will be rendered as JSON strings representing chat messages. Calling `Prompt.chat_messages`
+    will return a list of `ChatMessage` instances.
+
+    Example:
+        ```jinja
+        {% chat role="system" %}
+        You are a helpful assistant.
+        {% endchat %}
+
+        {% chat role="user" %}
+        Hello, how are you?
+        {% endchat %}
+        ```
+    """
+
+
+def completion(model_name: str):  # pylint: disable=W0613
+    """
+    `completion` can be used to send to the LLM the content of the block in form of messages.
+
+    The rendered value of the block can be used as is but it's usually more useful to
+    assign it to a variable and access it from another section of the prompt.
+
+    Example:
+        ```jinja
+        {% set response %}
+        {% completion model="gpt-3.5-turbo-0125" %}
+        {% chat role="user" %}You are a helpful assistant{% endchat %}
+        {% endcompletion %}
+        {% endset %}
+
+        {# output the response content #}
+        {{ response }}
+        ```
+    """
+
+
+def generate(model_name: str):  # pylint: disable=W0613
+    """
+    `generate` can be used to call the LiteLLM API passing the tag text as a prompt and get back some content.
+
+    Example:
+        ```jinja
+        {% generate "write a tweet with positive sentiment" "gpt-3.5-turbo" %}
+        Feeling grateful for all the opportunities that come my way! #positivity #productivity
+        ```
+    """

--- a/src/banks/extensions/generate.py
+++ b/src/banks/extensions/generate.py
@@ -15,19 +15,6 @@ DEFAULT_MODEL = "gpt-3.5-turbo"
 SYSTEM_PROMPT = Prompt("{{canary_word}} You are a helpful assistant.")
 
 
-# This function exists for documentation purpose.
-def generate(model_name: str):  # pylint: disable=W0613
-    """
-    `generate` can be used to call the LiteLLM API passing the tag text as a prompt and get back some content.
-
-    Example:
-        ```jinja
-        {% generate "write a tweet with positive sentiment" "gpt-3.5-turbo" %}
-        Feeling grateful for all the opportunities that come my way! #positivity #productivity
-        ```
-    """
-
-
 class GenerateExtension(Extension):
     # a set of names that trigger the extension.
     tags = {"generate"}  # noqa

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1,0 +1,36 @@
+from unittest import mock
+
+import pytest
+from jinja2.environment import Environment
+
+from banks.extensions.completion import CompletionExtension
+from banks.types import ChatMessage
+
+
+@pytest.fixture
+def ext():
+    return CompletionExtension(environment=Environment())
+
+
+def test__body_to_messages(ext):
+    assert ext._body_to_messages(" ") == []
+    assert ext._body_to_messages(' \n{"role":"user", "content":"hello"}') == [ChatMessage(role="user", content="hello")]
+    assert ext._body_to_messages(" \nhello\n ") == [ChatMessage(role="user", content="hello")]
+    assert ext._body_to_messages('{"role":"user", "content":"hello"}\n HELLO!') == [
+        ChatMessage(role="user", content="hello")
+    ]
+
+
+def test__do_completion(ext):
+    assert ext._do_completion("test-model", lambda: " ") == ""
+    with mock.patch("banks.extensions.completion.completion") as mocked_completion:
+        ext._do_completion("test-model", lambda: "hello")
+        mocked_completion.assert_called_with(model="test-model", messages=[ChatMessage(role="user", content="hello")])
+
+
+@pytest.mark.asyncio
+async def test__do_completion_async(ext):
+    assert await ext._do_completion_async("test-model", lambda: " ") == ""
+    with mock.patch("banks.extensions.completion.acompletion") as mocked_completion:
+        await ext._do_completion_async("test-model", lambda: "hello")
+        mocked_completion.assert_called_with(model="test-model", messages=[ChatMessage(role="user", content="hello")])


### PR DESCRIPTION
`completion` can be used to send to the LLM the content of the block in form of messages.

The rendered value of the block can be used as is but it's usually more useful to
assign it to a variable and access it from another section of the prompt.

Example:
```jinja
        {% set response %}
        {% completion model="gpt-3.5-turbo-0125" %}
        {% chat role="user" %}You are a helpful assistant{% endchat %}
        {% endcompletion %}
        {% endset %}

        {# output the response content #}
        {{ response }}
```