### PR TITLE
feat: Add function calling from `{% completion %}`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
+  "griffe",
   "jinja2",
   "litellm",
   "pydantic",
@@ -183,8 +184,9 @@ exclude_lines = [
 
 [[tool.mypy.overrides]]
 module = [
-  "simplemma.*",
+  # "griffe.*",
   "litellm.*",
+  "simplemma.*",
 ]
 ignore_missing_imports = true
 

--- a/src/banks/env.py
+++ b/src/banks/env.py
@@ -4,7 +4,7 @@
 from jinja2 import Environment, PackageLoader, select_autoescape
 
 from .config import config
-from .filters import cache_control, lemmatize
+from .filters import cache_control, lemmatize, tool
 
 
 def _add_extensions(_env):
@@ -40,4 +40,5 @@ env = Environment(
 # Setup custom filters and defaults
 env.filters["lemmatize"] = lemmatize
 env.filters["cache_control"] = cache_control
+env.filters["tool"] = tool
 _add_extensions(env)

--- a/src/banks/errors.py
+++ b/src/banks/errors.py
@@ -19,3 +19,7 @@ class PromptNotFoundError(Exception):
 
 class InvalidPromptError(Exception):
     """The prompt is not valid."""
+
+
+class LLMError(Exception):
+    """The LLM had problems."""

--- a/src/banks/extensions/chat.py
+++ b/src/banks/extensions/chat.py
@@ -108,4 +108,4 @@ class ChatExtension(Extension):
         parser = _ContentBlockParser()
         parser.feed(caller())
         cm = ChatMessage(role=role, content=parser.content)
-        return cm.model_dump_json()
+        return cm.model_dump_json(exclude_none=True) + "\n"

--- a/src/banks/extensions/completion.py
+++ b/src/banks/extensions/completion.py
@@ -99,7 +99,7 @@ class CompletionExtension(Extension):
         messages.append(choices[0].message)  # type:ignore
         for tool_call in tool_calls:
             if not tool_call.function.name:
-                msg = "Function name is empty"
+                msg = "Malformed response: function name is empty"
                 raise LLMError(msg)
 
             func = self._get_tool_callable(tools, tool_call)

--- a/src/banks/filters/__init__.py
+++ b/src/banks/filters/__init__.py
@@ -3,8 +3,10 @@
 # SPDX-License-Identifier: MIT
 from .cache_control import cache_control
 from .lemmatize import lemmatize
+from .tool import tool
 
 __all__ = (
     "cache_control",
     "lemmatize",
+    "tool",
 )

--- a/src/banks/filters/tool.py
+++ b/src/banks/filters/tool.py
@@ -7,5 +7,5 @@ from banks.types import Tool
 
 
 def tool(value: Callable) -> str:
-    tool = Tool.from_callable(value)
-    return tool.model_dump_json() + "\n"
+    t = Tool.from_callable(value)
+    return t.model_dump_json() + "\n"

--- a/src/banks/filters/tool.py
+++ b/src/banks/filters/tool.py
@@ -8,4 +8,4 @@ from banks.types import Tool
 
 def tool(value: Callable) -> str:
     tool = Tool.from_callable(value)
-    return tool.model_dump_json()
+    return tool.model_dump_json() + "\n"

--- a/src/banks/filters/tool.py
+++ b/src/banks/filters/tool.py
@@ -3,6 +3,9 @@
 # SPDX-License-Identifier: MIT
 from typing import Callable
 
+from banks.types import Tool
+
 
 def tool(value: Callable) -> str:
-    return f"Function {value}"
+    tool = Tool.from_callable(value)
+    return tool.model_dump_json()

--- a/src/banks/filters/tool.py
+++ b/src/banks/filters/tool.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2023-present Massimiliano Pippi <mpippi@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from typing import Callable
+
+
+def tool(value: Callable) -> str:
+    return f"Function {value}"

--- a/src/banks/types.py
+++ b/src/banks/types.py
@@ -5,7 +5,6 @@ from enum import Enum
 from inspect import Parameter, getdoc, signature
 from typing import Callable
 
-from litellm.types.utils import Message
 from pydantic import BaseModel
 from typing_extensions import Self
 
@@ -58,10 +57,6 @@ class ChatMessage(BaseModel):
     tool_call_id: str | None = None
     name: str | None = None
 
-    @classmethod
-    def from_litellm(cls, msg: Message) -> Self:
-        return cls(role=msg.role, content=msg.content or "")
-
 
 class FunctionParameter(BaseModel):
     type: str
@@ -102,6 +97,7 @@ class Tool(BaseModel):
                 "required": ["location"],
             },
         },
+        "import_path": "module.get_current_weather",
     }
     ```
     """

--- a/src/banks/types.py
+++ b/src/banks/types.py
@@ -2,8 +2,13 @@
 #
 # SPDX-License-Identifier: MIT
 from enum import Enum
+from inspect import Parameter, getdoc, signature
+from typing import Callable
 
 from pydantic import BaseModel
+from typing_extensions import Self
+
+from .utils import parse_params_from_docstring, python_type_to_jsonschema
 
 # pylint: disable=invalid-name
 
@@ -49,3 +54,86 @@ ChatMessageContent = list[ContentBlock] | str
 class ChatMessage(BaseModel):
     role: str
     content: str | ChatMessageContent
+
+
+class ChatWithToolMessage(ChatMessage):
+    tool_call_id: str
+    name: str
+
+
+class FunctionParameter(BaseModel):
+    type: str
+    description: str
+
+
+class FunctionParameters(BaseModel):
+    type: str = "object"
+    properties: dict[str, FunctionParameter]
+    required: list[str]
+
+
+class Function(BaseModel):
+    name: str
+    description: str
+    parameters: FunctionParameters
+
+
+class Tool(BaseModel):
+    """A model representing a Tool to be used in function calling.
+
+    This model should dump the following:
+    ```
+    {
+        "type": "function",
+        "function": {
+            "name": "get_current_weather",
+            "description": "Get the current weather in a given location",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {
+                        "type": "string",
+                        "description": "The city and state, e.g. San Francisco, CA",
+                    },
+                    "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                },
+                "required": ["location"],
+            },
+        },
+    }
+    ```
+    """
+
+    type: str = "function"
+    function: Function
+    _import_path: str
+
+    @classmethod
+    def from_callable(cls, func: Callable) -> Self:
+        sig = signature(func)
+
+        # Try getting params descriptions from docstrings
+        param_docs = parse_params_from_docstring(func.__doc__ or "")
+
+        # If the docstring is missing, use the qualname space-separated hopefully
+        # the LLM will get some more context than just using the function name.
+        description = getdoc(func) or " ".join(func.__qualname__.split("."))
+        properties = {}
+        required = []
+        for name, param in sig.parameters.items():
+            p = FunctionParameter(
+                description=param_docs.get(name, {}).get("description", ""),
+                type=python_type_to_jsonschema(param.annotation),
+            )
+            properties[name] = p
+            if param.default == Parameter.empty:
+                required.append(name)
+
+        return cls(
+            function=Function(
+                name=func.__name__,
+                description=description,
+                parameters=FunctionParameters(properties=properties, required=required),
+            ),
+            _import_path=f"{func.__module__}.{func.__qualname__}",
+        )

--- a/src/banks/utils.py
+++ b/src/banks/utils.py
@@ -30,19 +30,19 @@ def python_type_to_jsonschema(python_type: type) -> str:
     """Given a Python type, returns the jsonschema string describing it."""
     if python_type is str:
         return "string"
-    elif python_type is int:
+    if python_type is int:
         return "integer"
-    elif python_type is float:
+    if python_type is float:
         return "number"
-    elif python_type is bool:
+    if python_type is bool:
         return "boolean"
-    elif python_type is list:
+    if python_type is list:
         return "array"
-    elif python_type is dict:
+    if python_type is dict:
         return "object"
-    else:
-        msg = f"Unsupported type: {python_type}"
-        raise ValueError(msg)
+
+    msg = f"Unsupported type: {python_type}"
+    raise ValueError(msg)
 
 
 def parse_params_from_docstring(docstring: str) -> dict[str, dict[str, str]]:

--- a/src/banks/utils.py
+++ b/src/banks/utils.py
@@ -1,5 +1,7 @@
 import secrets
 
+from griffe import Docstring, parse_google, parse_numpy, parse_sphinx
+
 
 def strtobool(val: str) -> bool:
     """
@@ -22,3 +24,42 @@ def strtobool(val: str) -> bool:
 
 def generate_canary_word(prefix: str = "BANKS[", suffix: str = "]", token_length: int = 8) -> str:
     return f"{prefix}{secrets.token_hex(token_length // 2)}{suffix}"
+
+
+def python_type_to_jsonschema(python_type: type) -> str:
+    """Given a Python type, returns the jsonschema string describing it."""
+    if python_type is str:
+        return "string"
+    elif python_type is int:
+        return "integer"
+    elif python_type is float:
+        return "number"
+    elif python_type is bool:
+        return "boolean"
+    elif python_type is list:
+        return "array"
+    elif python_type is dict:
+        return "object"
+    else:
+        msg = f"Unsupported type: {python_type}"
+        raise ValueError(msg)
+
+
+def parse_params_from_docstring(docstring: str) -> dict[str, dict[str, str]]:
+    param_docs = []
+    ds = Docstring(docstring)
+    for parser in (parse_google, parse_numpy, parse_sphinx):
+        sections = parser(ds)
+        for section in sections:
+            if section.kind == "parameters":
+                param_docs = section.value
+                break
+        if param_docs:
+            break
+
+    ret = {}
+    for d in param_docs:
+        d_dict = d.as_dict()
+        ret[d_dict.pop("name")] = d_dict
+
+    return ret

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 from jinja2.environment import Environment
 
+from banks.errors import InvalidPromptError
 from banks.extensions.completion import CompletionExtension
 from banks.types import ChatMessage
 
@@ -12,25 +13,51 @@ def ext():
     return CompletionExtension(environment=Environment())
 
 
+@pytest.fixture
+def mocked_choices_no_tools():
+    return [mock.MagicMock(message=mock.MagicMock(tool_calls=None, content="some response"))]
+
+
 def test__body_to_messages(ext):
-    assert ext._body_to_messages(" ") == []
-    assert ext._body_to_messages(' \n{"role":"user", "content":"hello"}') == [ChatMessage(role="user", content="hello")]
-    assert ext._body_to_messages(" \nhello\n ") == [ChatMessage(role="user", content="hello")]
-    assert ext._body_to_messages('{"role":"user", "content":"hello"}\n HELLO!') == [
-        ChatMessage(role="user", content="hello")
-    ]
+    assert ext._body_to_messages(' \n{"role":"user", "content":"hello"}') == (
+        [ChatMessage(role="user", content="hello")],
+        [],
+    )
+    assert ext._body_to_messages('{"role":"user", "content":"hello"}\n HELLO!') == (
+        [ChatMessage(role="user", content="hello")],
+        [],
+    )
+    with pytest.raises(InvalidPromptError, match="Completion must contain at least one chat message"):
+        ext._body_to_messages(" ")
+    with pytest.raises(InvalidPromptError, match="Completion must contain at least one chat message"):
+        ext._body_to_messages(" \nhello\n ")
 
 
-def test__do_completion(ext):
-    assert ext._do_completion("test-model", lambda: " ") == ""
+def test__do_completion_no_prompt(ext):
+    with pytest.raises(InvalidPromptError, match="Completion must contain at least one chat message"):
+        ext._do_completion("test-model", lambda: " ")
+
+
+def test__do_completion_no_tools(ext, mocked_choices_no_tools):
     with mock.patch("banks.extensions.completion.completion") as mocked_completion:
-        ext._do_completion("test-model", lambda: "hello")
-        mocked_completion.assert_called_with(model="test-model", messages=[ChatMessage(role="user", content="hello")])
+        mocked_completion.return_value.choices = mocked_choices_no_tools
+        ext._do_completion("test-model", lambda: '{"role":"user", "content":"hello"}')
+        mocked_completion.assert_called_with(
+            model="test-model", messages=[ChatMessage(role="user", content="hello")], tools=[]
+        )
 
 
 @pytest.mark.asyncio
-async def test__do_completion_async(ext):
-    assert await ext._do_completion_async("test-model", lambda: " ") == ""
+async def test__do_completion_async_no_prompt(ext):
+    with pytest.raises(InvalidPromptError, match="Completion must contain at least one chat message"):
+        await ext._do_completion_async("test-model", lambda: " ")
+
+
+@pytest.mark.asyncio
+async def test__do_completion_async_no_prompt_no_tools(ext, mocked_choices_no_tools):
     with mock.patch("banks.extensions.completion.acompletion") as mocked_completion:
-        await ext._do_completion_async("test-model", lambda: "hello")
-        mocked_completion.assert_called_with(model="test-model", messages=[ChatMessage(role="user", content="hello")])
+        mocked_completion.return_value.choices = mocked_choices_no_tools
+        await ext._do_completion_async("test-model", lambda: '{"role":"user", "content":"hello"}')
+        mocked_completion.assert_called_with(
+            model="test-model", messages=[ChatMessage(role="user", content="hello")], tools=[]
+        )

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1,11 +1,13 @@
+from os import getenv
 from unittest import mock
 
 import pytest
 from jinja2.environment import Environment
+from litellm.types.utils import ChatCompletionMessageToolCall, Function
 
-from banks.errors import InvalidPromptError
+from banks.errors import InvalidPromptError, LLMError
 from banks.extensions.completion import CompletionExtension
-from banks.types import ChatMessage
+from banks.types import ChatMessage, Tool
 
 
 @pytest.fixture
@@ -16,6 +18,40 @@ def ext():
 @pytest.fixture
 def mocked_choices_no_tools():
     return [mock.MagicMock(message=mock.MagicMock(tool_calls=None, content="some response"))]
+
+
+@pytest.fixture
+def mocked_choices_with_tools():
+    return [
+        mock.MagicMock(
+            message=mock.MagicMock(
+                tool_calls=[
+                    ChatCompletionMessageToolCall(
+                        id="call_DN6IiLULWZw7sobV6puCji1O",
+                        function=Function(
+                            arguments='{"location": "San Francisco", "unit": "celsius"}', name="get_current_weather"
+                        ),
+                        type="function",
+                    ),
+                    ChatCompletionMessageToolCall(
+                        id="call_ERm1JfYO9AFo2oEWRmWUd40c",
+                        function=Function(
+                            arguments='{"location": "Tokyo", "unit": "celsius"}', name="get_current_weather"
+                        ),
+                        type="function",
+                    ),
+                    ChatCompletionMessageToolCall(
+                        id="call_2lvUVB1y4wKunSxTenR0zClP",
+                        function=Function(
+                            arguments='{"location": "Paris", "unit": "celsius"}', name="get_current_weather"
+                        ),
+                        type="function",
+                    ),
+                ],
+                content="some response",
+            )
+        )
+    ]
 
 
 def test__body_to_messages(ext):
@@ -47,6 +83,30 @@ def test__do_completion_no_tools(ext, mocked_choices_no_tools):
         )
 
 
+def test__do_completion_with_tools(ext, mocked_choices_with_tools):
+    ext._get_tool_callable = mock.MagicMock(return_value=lambda location, unit: f"I got {location} with {unit}")
+    ext._body_to_messages = mock.MagicMock(return_value=(["message1", "message2"], ["tool1", "tool2"]))
+    with mock.patch("banks.extensions.completion.completion") as mocked_completion:
+        mocked_completion.return_value.choices = mocked_choices_with_tools
+        ext._do_completion("test-model", lambda: '{"role":"user", "content":"hello"}')
+        calls = mocked_completion.call_args_list
+        assert len(calls) == 2  # complete query, complete with tool results
+        assert calls[0].kwargs["tools"] == ["tool1", "tool2"]
+        assert "tools" not in calls[1].kwargs
+        for m in calls[1].kwargs["messages"]:
+            if type(m) == ChatMessage:
+                assert m.role == "tool"
+                assert m.name == "get_current_weather"
+
+
+def test__do_completion_with_tools_malformed(ext, mocked_choices_with_tools):
+    mocked_choices_with_tools[0].message.tool_calls[0].function.name = None
+    with mock.patch("banks.extensions.completion.completion") as mocked_completion:
+        mocked_completion.return_value.choices = mocked_choices_with_tools
+        with pytest.raises(LLMError):
+            ext._do_completion("test-model", lambda: '{"role":"user", "content":"hello"}')
+
+
 @pytest.mark.asyncio
 async def test__do_completion_async_no_prompt(ext):
     with pytest.raises(InvalidPromptError, match="Completion must contain at least one chat message"):
@@ -61,3 +121,40 @@ async def test__do_completion_async_no_prompt_no_tools(ext, mocked_choices_no_to
         mocked_completion.assert_called_with(
             model="test-model", messages=[ChatMessage(role="user", content="hello")], tools=[]
         )
+
+
+def test__get_tool_callable(ext):
+    tools = [
+        Tool.model_validate(
+            {
+                "type": "function",
+                "function": {
+                    "name": "getenv",
+                    "description": "Get an environment variable, return None if it doesn't exist.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "description": "The name of the environment variable",
+                            },
+                            "default": {
+                                "type": "string",
+                                "description": "The value to return if the variable was not found",
+                            },
+                        },
+                        "required": ["key"],
+                    },
+                },
+                "import_path": "os.getenv",
+            }
+        )
+    ]
+    tool_call = mock.MagicMock()
+
+    tool_call.function.name = "getenv"
+    assert ext._get_tool_callable(tools, tool_call) == getenv
+
+    tool_call.function.name = "another_func"
+    with pytest.raises(ValueError, match="Function another_func not found in available tools"):
+        ext._get_tool_callable(tools, tool_call)

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -94,7 +94,7 @@ def test__do_completion_with_tools(ext, mocked_choices_with_tools):
         assert calls[0].kwargs["tools"] == ["tool1", "tool2"]
         assert "tools" not in calls[1].kwargs
         for m in calls[1].kwargs["messages"]:
-            if type(m) == ChatMessage:
+            if type(m) is ChatMessage:
                 assert m.role == "tool"
                 assert m.name == "get_current_weather"
 

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -89,9 +89,13 @@ def test_chat_messages():
         p.text()
         == """
 {"role":"system","content":"You are a helpful assistant.\\n"}
+
 {"role":"user","content":"Hello, how are you?\\n"}
+
 {"role":"system","content":"I'm doing well, thank you! How can I assist you today?\\n"}
+
 {"role":"user","content":"Can you explain quantum computing?\\n"}
+
 Some random text.
 """.strip()
     )

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -1,0 +1,56 @@
+import inspect
+
+from banks.filters import tool
+from banks.types import Tool
+
+
+def test_tool():
+    def my_tool_function(myparam: str):
+        """Description of the tool.
+
+        Args:
+            myparam (str): description of the parameter
+
+        """
+        pass
+
+    tool_dump = tool(my_tool_function)
+    t = Tool.model_validate_json(tool_dump)
+    assert t.model_dump() == {
+        "function": {
+            "description": inspect.getdoc(my_tool_function),
+            "name": "my_tool_function",
+            "parameters": {
+                "properties": {"myparam": {"description": "description " "of the " "parameter", "type": "string"}},
+                "required": ["myparam"],
+                "type": "object",
+            },
+        },
+        "type": "function",
+    }
+
+
+def test_tool_with_defaults():
+    def my_tool_function(myparam: str = ""):
+        """Description of the tool.
+
+        Args:
+            myparam (str): description of the parameter
+
+        """
+        pass
+
+    tool_dump = tool(my_tool_function)
+    t = Tool.model_validate_json(tool_dump)
+    assert t.model_dump() == {
+        "function": {
+            "description": inspect.getdoc(my_tool_function),
+            "name": "my_tool_function",
+            "parameters": {
+                "properties": {"myparam": {"description": "description " "of the " "parameter", "type": "string"}},
+                "required": [],
+                "type": "object",
+            },
+        },
+        "type": "function",
+    }

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -17,16 +17,17 @@ def test_tool():
     tool_dump = tool(my_tool_function)
     t = Tool.model_validate_json(tool_dump)
     assert t.model_dump() == {
+        "type": "function",
         "function": {
-            "description": inspect.getdoc(my_tool_function),
             "name": "my_tool_function",
+            "description": "Description of the tool.\n\nArgs:\n    myparam (str): description of the parameter",
             "parameters": {
-                "properties": {"myparam": {"description": "description " "of the " "parameter", "type": "string"}},
-                "required": ["myparam"],
                 "type": "object",
+                "properties": {"myparam": {"type": "string", "description": "description of the parameter"}},
+                "required": ["myparam"],
             },
         },
-        "type": "function",
+        "import_path": "tests.test_tool.test_tool.<locals>.my_tool_function",
     }
 
 
@@ -43,14 +44,15 @@ def test_tool_with_defaults():
     tool_dump = tool(my_tool_function)
     t = Tool.model_validate_json(tool_dump)
     assert t.model_dump() == {
+        "type": "function",
         "function": {
-            "description": inspect.getdoc(my_tool_function),
             "name": "my_tool_function",
+            "description": "Description of the tool.\n\nArgs:\n    myparam (str): description of the parameter",
             "parameters": {
-                "properties": {"myparam": {"description": "description " "of the " "parameter", "type": "string"}},
-                "required": [],
                 "type": "object",
+                "properties": {"myparam": {"type": "string", "description": "description of the parameter"}},
+                "required": [],
             },
         },
-        "type": "function",
+        "import_path": "tests.test_tool.test_tool_with_defaults.<locals>.my_tool_function",
     }

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -1,5 +1,3 @@
-import inspect
-
 from banks.filters import tool
 from banks.types import Tool
 


### PR DESCRIPTION
Working example:
```py
import json

from banks import Prompt


def get_current_weather(location: str):
    """Get the current weather in a given location"""
    if "tokyo" in location.lower():
        return json.dumps({"location": "Tokyo", "temperature": "10", "unit": "celsius"})
    elif "san francisco" in location.lower():
        return json.dumps({"location": "San Francisco", "temperature": "72", "unit": "fahrenheit"})
    elif "paris" in location.lower():
        return json.dumps({"location": "Paris", "temperature": "22", "unit": "celsius"})
    else:
        return json.dumps({"location": location, "temperature": "unknown"})


p = Prompt("""
{% set response %}
{% completion model="gpt-3.5-turbo-0125" %}
    {% chat role="user" %}
           What's the weather like in {{ query }}?
    {% endchat %}
    {{ get_current_weather | tool }}
{% endcompletion %}
{% endset %}

{# the variable 'response' contains the result #}

{{ response }}
""")

print(p.text({"query": "Paris", "get_current_weather": get_current_weather}))
```