### PR TITLE
feat: Make litellm and redis optional dependencies, adding `minimal` extra install option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "banks"
 dynamic = ["version"]
 description = 'A prompt programming language'
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 license = "MIT"
 keywords = []
 authors = [{ name = "Massimiliano Pippi", email = "mpippi@gmail.com" }]
@@ -27,6 +27,16 @@ dependencies = [
     "pydantic",
     "deprecated",
     "redis",
+    "eval-type-backport;python_version<'3.10'",
+]
+
+[project.optional-dependencies]
+minimal = [
+    "griffe",
+    "jinja2",
+    "pydantic",
+    "deprecated",
+    "eval-type-backport;python_version<'3.10'",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,8 @@ disable = [
     "missing-class-docstring",
     "missing-function-docstring",
     "cyclic-import",
+    "import-outside-toplevel",
+    "too-many-locals",
 ]
 max-args = 10
 

--- a/src/banks/__init__.py
+++ b/src/banks/__init__.py
@@ -8,5 +8,4 @@ from .env import env
 from .prompt import AsyncPrompt, Prompt
 from .types import ChatMessage
 
-
 __all__ = ("env", "Prompt", "AsyncPrompt", "config", "ChatMessage")

--- a/src/banks/__init__.py
+++ b/src/banks/__init__.py
@@ -5,5 +5,6 @@ from .config import config
 from .env import env
 from .prompt import AsyncPrompt, Prompt
 from .types import ChatMessage
+from __future__ import annotations
 
 __all__ = ("env", "Prompt", "AsyncPrompt", "config", "ChatMessage")

--- a/src/banks/__init__.py
+++ b/src/banks/__init__.py
@@ -1,10 +1,12 @@
 # SPDX-FileCopyrightText: 2023-present Massimiliano Pippi <mpippi@gmail.com>
 #
 # SPDX-License-Identifier: MIT
+from __future__ import annotations
+
 from .config import config
 from .env import env
 from .prompt import AsyncPrompt, Prompt
 from .types import ChatMessage
-from __future__ import annotations
+
 
 __all__ = ("env", "Prompt", "AsyncPrompt", "config", "ChatMessage")

--- a/src/banks/extensions/completion.py
+++ b/src/banks/extensions/completion.py
@@ -90,8 +90,8 @@ class CompletionExtension(Extension):
         try:
             from litellm import completion
             from litellm.types.utils import Choices, ModelResponse
-        except ImportError:
-            raise ImportError(LITELLM_INSTALL_MSG)
+        except ImportError as e:
+            raise ImportError(LITELLM_INSTALL_MSG) from e
 
         messages, tools = self._body_to_messages(caller())
         message_dicts = [m.model_dump() for m in messages]
@@ -130,8 +130,8 @@ class CompletionExtension(Extension):
         try:
             from litellm import acompletion
             from litellm.types.utils import Choices, ModelResponse
-        except ImportError:
-            raise ImportError(LITELLM_INSTALL_MSG)
+        except ImportError as e:
+            raise ImportError(LITELLM_INSTALL_MSG) from e
 
         messages, tools = self._body_to_messages(caller())
         message_dicts = [m.model_dump() for m in messages]

--- a/src/banks/extensions/completion.py
+++ b/src/banks/extensions/completion.py
@@ -7,14 +7,13 @@ from typing import cast
 
 from jinja2 import TemplateSyntaxError, nodes
 from jinja2.ext import Extension
-from litellm import acompletion, completion
-from litellm.types.utils import Choices, ModelResponse
 from pydantic import ValidationError
 
 from banks.errors import InvalidPromptError, LLMError
 from banks.types import ChatMessage, Tool
 
 SUPPORTED_KWARGS = ("model",)
+LITELLM_INSTALL_MSG = "litellm is not installed. Please install it with `pip install litellm`."
 
 
 class CompletionExtension(Extension):
@@ -88,6 +87,12 @@ class CompletionExtension(Extension):
         """
         Helper callback.
         """
+        try:
+            from litellm import completion
+            from litellm.types.utils import Choices, ModelResponse
+        except ImportError:
+            raise ImportError(LITELLM_INSTALL_MSG)
+
         messages, tools = self._body_to_messages(caller())
         message_dicts = [m.model_dump() for m in messages]
         tool_dicts = [t.model_dump() for t in tools] or None
@@ -122,6 +127,12 @@ class CompletionExtension(Extension):
         """
         Helper callback.
         """
+        try:
+            from litellm import acompletion
+            from litellm.types.utils import Choices, ModelResponse
+        except ImportError:
+            raise ImportError(LITELLM_INSTALL_MSG)
+
         messages, tools = self._body_to_messages(caller())
         message_dicts = [m.model_dump() for m in messages]
         tool_dicts = [t.model_dump() for t in tools] or None

--- a/src/banks/registries/redis.py
+++ b/src/banks/registries/redis.py
@@ -27,8 +27,8 @@ class RedisPromptRegistry:
         """
         try:
             import redis
-        except ImportError:
-            raise ImportError(REDIS_INSTALL_MSG)
+        except ImportError as e:
+            raise ImportError(REDIS_INSTALL_MSG) from e
 
         self._redis = redis.from_url(redis_url, decode_responses=True)
         self._prefix = prefix

--- a/src/banks/registries/redis.py
+++ b/src/banks/registries/redis.py
@@ -1,11 +1,11 @@
 import json
 from typing import cast
 
-import redis
-
 from banks import Prompt
 from banks.errors import InvalidPromptError, PromptNotFoundError
 from banks.prompt import DEFAULT_VERSION, PromptModel
+
+REDIS_INSTALL_MSG = "redis is not installed. Please install it with `pip install redis`."
 
 
 class RedisPromptRegistry:
@@ -23,6 +23,11 @@ class RedisPromptRegistry:
             redis_url: Redis connection URL
             prefix: Key prefix for storing prompts in Redis
         """
+        try:
+            import redis
+        except ImportError:
+            raise ImportError(REDIS_INSTALL_MSG)
+
         self._redis = redis.from_url(redis_url, decode_responses=True)
         self._prefix = prefix
 

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -111,7 +111,7 @@ async def test__do_completion_async_no_prompt(ext):
 
 
 def test__do_completion_no_tools(ext, mocked_choices_no_tools):
-    with mock.patch("banks.extensions.completion.completion") as mocked_completion:
+    with mock.patch("litellm.completion") as mocked_completion:
         mocked_completion.return_value.choices = mocked_choices_no_tools
         ext._do_completion("test-model", lambda: '{"role":"user", "content":"hello"}')
         mocked_completion.assert_called_with(
@@ -121,7 +121,7 @@ def test__do_completion_no_tools(ext, mocked_choices_no_tools):
 
 @pytest.mark.asyncio
 async def test__do_completion_async_no_tools(ext, mocked_choices_no_tools):
-    with mock.patch("banks.extensions.completion.acompletion") as mocked_completion:
+    with mock.patch("litellm.acompletion") as mocked_completion:
         mocked_completion.return_value.choices = mocked_choices_no_tools
         await ext._do_completion_async("test-model", lambda: '{"role":"user", "content":"hello"}')
         mocked_completion.assert_called_with(
@@ -139,7 +139,7 @@ def test__do_completion_with_tools(ext, mocked_choices_with_tools):
             [mock.MagicMock(), mock.MagicMock()],
         )
     )
-    with mock.patch("banks.extensions.completion.completion") as mocked_completion:
+    with mock.patch("litellm.completion") as mocked_completion:
         mocked_completion.return_value.choices = mocked_choices_with_tools
         ext._do_completion("test-model", lambda: '{"role":"user", "content":"hello"}')
         calls = mocked_completion.call_args_list
@@ -160,7 +160,7 @@ async def test__do_completion_async_with_tools(ext, mocked_choices_with_tools, t
             tools,
         )
     )
-    with mock.patch("banks.extensions.completion.acompletion") as mocked_completion:
+    with mock.patch("litellm.acompletion") as mocked_completion:
         mocked_completion.return_value.choices = mocked_choices_with_tools
         await ext._do_completion_async("test-model", lambda: '{"role":"user", "content":"hello"}')
         calls = mocked_completion.call_args_list
@@ -174,7 +174,7 @@ async def test__do_completion_async_with_tools(ext, mocked_choices_with_tools, t
 
 def test__do_completion_with_tools_malformed(ext, mocked_choices_with_tools):
     mocked_choices_with_tools[0].message.tool_calls[0].function.name = None
-    with mock.patch("banks.extensions.completion.completion") as mocked_completion:
+    with mock.patch("litellm.completion") as mocked_completion:
         mocked_completion.return_value.choices = mocked_choices_with_tools
         with pytest.raises(LLMError):
             ext._do_completion("test-model", lambda: '{"role":"user", "content":"hello"}')
@@ -183,7 +183,7 @@ def test__do_completion_with_tools_malformed(ext, mocked_choices_with_tools):
 @pytest.mark.asyncio
 async def test__do_completion_async_with_tools_malformed(ext, mocked_choices_with_tools):
     mocked_choices_with_tools[0].message.tool_calls[0].function.name = None
-    with mock.patch("banks.extensions.completion.acompletion") as mocked_completion:
+    with mock.patch("litellm.acompletion") as mocked_completion:
         mocked_completion.return_value.choices = mocked_choices_with_tools
         with pytest.raises(LLMError):
             await ext._do_completion_async("test-model", lambda: '{"role":"user", "content":"hello"}')
@@ -191,7 +191,7 @@ async def test__do_completion_async_with_tools_malformed(ext, mocked_choices_wit
 
 @pytest.mark.asyncio
 async def test__do_completion_async_no_prompt_no_tools(ext, mocked_choices_no_tools):
-    with mock.patch("banks.extensions.completion.acompletion") as mocked_completion:
+    with mock.patch("litellm.acompletion") as mocked_completion:
         mocked_completion.return_value.choices = mocked_choices_no_tools
         await ext._do_completion_async("test-model", lambda: '{"role":"user", "content":"hello"}')
         mocked_completion.assert_called_with(


### PR DESCRIPTION
This is a non-breaking change that
1. Adds python3.9 support
2. Adds python3.9 to tests
3. Adds a new `minimal` install option that removes redis and litellm
4. Make redis and litellm conditional imports so as to not break things for users that aren't using these features