### PR TITLE
feat: add `variables` property to the Prompt class

### DIFF
--- a/src/banks/prompt.py
+++ b/src/banks/prompt.py
@@ -11,6 +11,7 @@ try:
 except ImportError:  # pragma: no cover
     from typing_extensions import Self
 
+from jinja2 import meta
 from pydantic import BaseModel, ValidationError
 
 from .cache import DefaultCache, RenderCache
@@ -77,6 +78,11 @@ class BasePrompt:
     @property
     def version(self) -> str | None:
         return self._version
+
+    @property
+    def variables(self) -> set[str]:
+        ast = env.parse(self.raw)
+        return meta.find_undeclared_variables(ast)
 
     def canary_leaked(self, text: str) -> bool:
         """Returns whether the canary word is present in `text`, signalling the prompt might have leaked."""

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -119,3 +119,9 @@ def test_chat_message_no_chat_tag():
     text = "This is raw text"
     p = Prompt(text=text)
     assert p.chat_messages() == [ChatMessage(role="user", content=text)]
+
+
+def test_variables():
+    prompt_text = "This is a {{ first_variable.content }} and this is {{ another_variable }}"
+    p = Prompt(text=prompt_text)
+    assert p.variables == {"another_variable", "first_variable"}


### PR DESCRIPTION
`Prompt.variables` returns a set with all the variable names contained in the prompt template.

Note: for variable attributes like `{{ variable.field }}`, the property will return `variable`.

Fixes #36 