### PR TITLE
[breaking] fix deps again

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Docs are available [here](https://masci.github.io/banks/).
 
 ```console
 pip install banks
+
+# install optional deps; litellm, redis
+pip install "banks[all]"
 ```
 
 ## Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ python = ["3.10", "3.11", "3.12"]
 
 [tool.hatch.envs.lint]
 detached = false                                          # Normally the linting env can be detached, but mypy doesn't install all the stubs we need
-dependencies = ["mypy>=1.0.0", "ruff>=0.0.243", "pylint"]
+dependencies = ["mypy>=1.0.0", "ruff>=0.0.243", "pylint", "redis", "litellm"]
 
 [tool.hatch.envs.lint.scripts]
 check = ["ruff format --check {args}", "ruff check {args:.}"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,8 @@ dependencies = [
     "mkdocstrings[python]",
     "simplemma",
     "eval-type-backport;python_version<'3.10'",
+    "redis",
+    "litellm",
 ]
 
 [tool.hatch.envs.default.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,20 +24,15 @@ classifiers = [
 dependencies = [
     "griffe",
     "jinja2",
-    "litellm",
     "pydantic",
     "deprecated",
-    "redis",
     "eval-type-backport;python_version<'3.10'",
 ]
 
 [project.optional-dependencies]
-minimal = [
-    "griffe",
-    "jinja2",
-    "pydantic",
-    "deprecated",
-    "eval-type-backport;python_version<'3.10'",
+all = [
+    "litellm",
+    "redis",
 ]
 
 [project.urls]


### PR DESCRIPTION
So, somehow I thought the deps/extras setup I added before in #37 were working, but a `pip install banks[minimal]` now that its published shows that redis and litellm are still installed

I think the only solution is a breaking change, like the change in this PR.

The imports are already guarded for these two packages, so it will at least be clear to users that the need this in their deps.

Open to a conversation on this if a breaking change is not desired!