### PR TITLE
feat: add audio block to chat messages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4
@@ -47,21 +47,21 @@ jobs:
       - name: Install Hatch
         run: pip install --upgrade hatch
 
-      - if: matrix.python-version == '3.12'
+      - if: matrix.python-version == '3.13'
         name: Lint
         run: hatch run lint:all
 
       - name: Run tests
         run: hatch run cov -m"not e2e"
 
-      - if: matrix.python-version == '3.12'
+      - if: matrix.python-version == '3.13'
         name: End-to-end
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: hatch run test -m"e2e"
 
-      - if: matrix.python-version == '3.12'
+      - if: matrix.python-version == '3.13'
         name: Report Coveralls
         uses: coverallsapp/github-action@v2
 
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4
@@ -95,7 +95,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
@@ -66,7 +67,7 @@ cov = ["test-cov", "cov-report"]
 docs = "mkdocs {args:build}"
 
 [[tool.hatch.envs.all.matrix]]
-python = ["3.10", "3.11", "3.12"]
+python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
 [tool.hatch.envs.lint]
 detached = false                                          # Normally the linting env can be detached, but mypy doesn't install all the stubs we need

--- a/src/banks/types.py
+++ b/src/banks/types.py
@@ -8,7 +8,7 @@ import re
 from enum import Enum
 from inspect import Parameter, getdoc, signature
 from pathlib import Path
-from typing import Callable, Literal, Union
+from typing import Callable, Literal, Union, cast
 
 from pydantic import BaseModel
 from typing_extensions import Self
@@ -42,15 +42,19 @@ class ImageUrl(BaseModel):
             return cls.from_base64("image/jpeg", base64.b64encode(image_file.read()).decode("utf-8"))
 
 
+AudioFormat = Literal["mp3", "wav", "m4a", "webm", "ogg", "flac"]
+
+
 class InputAudio(BaseModel):
     data: str
-    format: Literal["mp3", "wav", "m4a", "webm", "ogg", "flac"]
+    format: AudioFormat
 
     @classmethod
     def from_path(cls, file_path: Path) -> Self:
         with open(file_path, "rb") as audio_file:
             encoded_str = base64.b64encode(audio_file.read()).decode("utf-8")
-            return cls(data=encoded_str, format=file_path.suffix[1:])
+            file_format = cast(AudioFormat, file_path.suffix[1:])
+            return cls(data=encoded_str, format=file_format)
 
 
 class ContentBlock(BaseModel):

--- a/src/banks/types.py
+++ b/src/banks/types.py
@@ -8,7 +8,7 @@ import re
 from enum import Enum
 from inspect import Parameter, getdoc, signature
 from pathlib import Path
-from typing import Callable, Union
+from typing import Callable, Literal, Union
 
 from pydantic import BaseModel
 from typing_extensions import Self
@@ -22,6 +22,7 @@ CONTENT_BLOCK_REGEX = re.compile(r"<content_block>((?s:.)*)<\/content_block>")
 class ContentBlockType(str, Enum):
     text = "text"
     image_url = "image_url"
+    audio = "audio"
 
 
 class CacheControl(BaseModel):
@@ -41,11 +42,23 @@ class ImageUrl(BaseModel):
             return cls.from_base64("image/jpeg", base64.b64encode(image_file.read()).decode("utf-8"))
 
 
+class InputAudio(BaseModel):
+    data: str
+    format: Literal["mp3", "wav", "m4a", "webm", "ogg", "flac"]
+
+    @classmethod
+    def from_path(cls, file_path: Path) -> Self:
+        with open(file_path, "rb") as audio_file:
+            encoded_str = base64.b64encode(audio_file.read()).decode("utf-8")
+            return cls(data=encoded_str, format=file_path.suffix[1:])
+
+
 class ContentBlock(BaseModel):
     type: ContentBlockType
     cache_control: CacheControl | None = None
     text: str | None = None
     image_url: ImageUrl | None = None
+    input_audio: InputAudio | None = None
 
 
 ChatMessageContent = Union[list[ContentBlock], str]

--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -5,4 +5,6 @@ def test_cache_control():
     res = cache_control("foo", "ephemeral")
     res = res.replace("<content_block>", "")
     res = res.replace("</content_block>", "")
-    assert res == '{"type":"text","cache_control":{"type":"ephemeral"},"text":"foo","image_url":null}'
+    assert (
+        res == '{"type":"text","cache_control":{"type":"ephemeral"},"text":"foo","image_url":null,"input_audio":null}'
+    )

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from banks.types import ImageUrl
+from banks.types import ImageUrl, InputAudio
 
 
 def test_image_url_from_base64():
@@ -39,3 +39,23 @@ def test_image_url_from_path_nonexistent():
     """Test creating ImageUrl from a nonexistent file path"""
     with pytest.raises(FileNotFoundError):
         ImageUrl.from_path(Path("nonexistent.jpg"))
+
+
+def test_input_audio_from_path(tmp_path):
+    """Test creating InputAudio from a file path"""
+    # Create a temporary test image file
+    test_audio = tmp_path / "test_audio.wav"
+    test_content = b"fake audio data"
+    test_audio.write_bytes(test_content)
+
+    input_audio = InputAudio.from_path(test_audio)
+
+    assert input_audio.format == "wav"
+    decoded_content = base64.b64decode(input_audio.data)
+    assert decoded_content == test_content
+
+
+def test_input_audio_from_path_nonexistent():
+    """Test creating ImageUrl from a nonexistent file path"""
+    with pytest.raises(FileNotFoundError):
+        InputAudio.from_path(Path("nonexistent.wav"))


### PR DESCRIPTION
Part of #35 

Add support for audio blocks. Based on OpenAI api, but the new block type tracks audio data and format, so it should be generic enough.