### PR TITLE
Support string as input for DirectoryPromptRegistry and FilePromptRegistry and documentation correction

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -252,10 +252,10 @@ from a directory in the file system. Suppose you have a folder called `templates
 and the folder contains a file called `blog.jinja`. You can load the prompt template like this:
 
 ```py
-from banks import Prompt
-from banks.registries import DirectoryTemplateRegistry
+from banks.registries import directory
 
-registry = DirectoryTemplateRegistry(populated_dir)
+populated_dir="./templates/"
+registry = directory.DirectoryTemplateRegistry(populated_dir)
 prompt = registry.get(name="blog")
 
 print(prompt.text({"topic": "retrogame computing"}))

--- a/src/banks/registries/directory.py
+++ b/src/banks/registries/directory.py
@@ -68,12 +68,12 @@ class DirectoryPromptRegistry:
         Raises:
             ValueError: If directory_path is not a directory
         """
-        directory_path = Path(directory_path)
-        if not directory_path.is_dir():
+        dir_path = Path(directory_path)
+        if not dir_path.is_dir():
             msg = "{directory_path} must be a directory."
             raise ValueError(msg)
 
-        self._path = directory_path
+        self._path = dir_path
         self._index_path = self._path / DEFAULT_INDEX_NAME
         if not self._index_path.exists() or force_reindex:
             self._scan()

--- a/src/banks/registries/directory.py
+++ b/src/banks/registries/directory.py
@@ -57,7 +57,7 @@ class PromptFileIndex(BaseModel):
 class DirectoryPromptRegistry:
     """Registry that stores prompts as files in a directory structure."""
 
-    def __init__(self, directory_path: Path, *, force_reindex: bool = False):
+    def __init__(self, directory_path: str, *, force_reindex: bool = False):
         """
         Initialize the directory prompt registry.
 
@@ -68,6 +68,7 @@ class DirectoryPromptRegistry:
         Raises:
             ValueError: If directory_path is not a directory
         """
+        directory_path = Path(directory_path)
         if not directory_path.is_dir():
             msg = "{directory_path} must be a directory."
             raise ValueError(msg)

--- a/src/banks/registries/file.py
+++ b/src/banks/registries/file.py
@@ -32,7 +32,7 @@ class PromptRegistryIndex(BaseModel):
 class FilePromptRegistry:
     """A prompt registry storing all prompt data in a single JSON file."""
 
-    def __init__(self, registry_index: Path) -> None:
+    def __init__(self, registry_index: str) -> None:
         """
         Initialize the file prompt registry.
 
@@ -42,7 +42,7 @@ class FilePromptRegistry:
         Note:
             Creates parent directories if they don't exist.
         """
-        self._index_fpath: Path = registry_index
+        self._index_fpath: Path = Path(registry_index)
         self._index: PromptRegistryIndex = PromptRegistryIndex(prompts=[])
         try:
             self._index = PromptRegistryIndex.model_validate_json(self._index_fpath.read_text())

--- a/src/banks/registries/file.py
+++ b/src/banks/registries/file.py
@@ -45,7 +45,7 @@ class FilePromptRegistry:
         self._index_fpath: Path = Path(registry_index)
         self._index: PromptRegistryIndex = PromptRegistryIndex(prompts=[])
         try:
-            self._index = PromptRegistryIndex.model_validate_json(self._index_fpath.read_text())
+            self._index = PromptRegistryIndex.model_validate_json(self._index_fpath.read_text(encoding="utf-8"))
         except FileNotFoundError:
             # init the user data folder
             self._index_fpath.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
> Closes #43

Hello, as discussed in #43, I introduced the following changes:

- `DirectoryPromptRegistry` and `FilePromptRegistry` now take strings as input for directory/file path and performs the conversion to `pathlib.Path` object on the fly during class intialization
- Corrected the slight mistake I found related to `DirectoryPromptRegistry` in the documentatio

Following the contribution guidelines, I:

- [X] Run the tests (no problems found)
- [X] Linted the code (no problems found)
- [X] Checked whether documentation website was still functional (no problems found)

Hope this looks good to you, and if I need to add anything, just let me know! 

Best,
Clelia
