### PR TITLE
improve content block regex

### DIFF
--- a/src/banks/types.py
+++ b/src/banks/types.py
@@ -18,6 +18,7 @@ from .utils import parse_params_from_docstring, python_type_to_jsonschema
 # pylint: disable=invalid-name
 CONTENT_BLOCK_REGEX = re.compile(r"(<content_block>\{.*?\}<\/content_block>)|([^<](?:(?!<content_block>).)*)")
 
+
 class ContentBlockType(str, Enum):
     text = "text"
     image_url = "image_url"

--- a/src/banks/types.py
+++ b/src/banks/types.py
@@ -165,7 +165,9 @@ def chat_message_from_text(role: str, content: str) -> ChatMessage:
     for match in matches:
         if match.group(1):
             # content block match
-            content_block_json_str = match.group(1).strip().lstrip("<content_block>").rstrip("</content_block>")
+            content_block_json_str = (
+                match.group(1).strip().removeprefix("<content_block>").removesuffix("</content_block>")
+            )
             content_blocks.append(ContentBlock.model_validate_json(content_block_json_str))
         elif match.group(2):
             # plain-text match

--- a/src/banks/types.py
+++ b/src/banks/types.py
@@ -16,8 +16,7 @@ from typing_extensions import Self
 from .utils import parse_params_from_docstring, python_type_to_jsonschema
 
 # pylint: disable=invalid-name
-CONTENT_BLOCK_REGEX = re.compile(r"<content_block>((?s:.)*)<\/content_block>")
-
+CONTENT_BLOCK_REGEX = re.compile(r"(<content_block>\{.*?\}<\/content_block>)|([^<](?:(?!<content_block>).)*)")
 
 class ContentBlockType(str, Enum):
     text = "text"
@@ -162,23 +161,16 @@ def chat_message_from_text(role: str, content: str) -> ChatMessage:
 
     # Find all content block matches
     matches = CONTENT_BLOCK_REGEX.finditer(content)
-    last_end = 0
     for match in matches:
-        # If there's text before the match, add it as a text content block
-        if match.start() > last_end:
-            text = content[last_end : match.start()].strip()
+        if match.group(1):
+            # content block match
+            content_block_json_str = match.group(1).strip().lstrip("<content_block>").rstrip("</content_block>")
+            content_blocks.append(ContentBlock.model_validate_json(content_block_json_str))
+        elif match.group(2):
+            # plain-text match
+            text = match.group(2).strip()
             if text:
                 content_blocks.append(ContentBlock(type=ContentBlockType.text, text=text))
-
-        # Add the parsed content block
-        content_blocks.append(ContentBlock.model_validate_json(match.group(1)))
-        last_end = match.end()
-
-    # Add any remaining text after the last match
-    if last_end < len(content):
-        text = content[last_end:].strip()
-        if text:
-            content_blocks.append(ContentBlock(type=ContentBlockType.text, text=text))
 
     # If no content blocks were found, treat entire content as text
     if not content_blocks:


### PR DESCRIPTION
Fixes #46 

Improves the content block regex to mix and match text and normal content blocks. Also simplifies the code since we don't have to keep track of matching indexes/locations 