### PR TITLE
fix: add platformdirs as dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "pydantic",
     "deprecated",
     "eval-type-backport;python_version<'3.10'",
+    "platformdirs",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
See title, dependency is required but missing from project definition

Fixes #45 