### PR TITLE
fix: detect multiline text blocks interleaved with image blocks

### DIFF
--- a/src/banks/types.py
+++ b/src/banks/types.py
@@ -16,7 +16,7 @@ from typing_extensions import Self
 from .utils import parse_params_from_docstring, python_type_to_jsonschema
 
 # pylint: disable=invalid-name
-CONTENT_BLOCK_REGEX = re.compile(r"(<content_block>\{.*?\}<\/content_block>)|([^<](?:(?!<content_block>).)*)")
+CONTENT_BLOCK_REGEX = re.compile(r"(<content_block>\{.*?\}<\/content_block>)|([^<](?:(?!<content_block>)[\s\S])*)")
 
 
 class ContentBlockType(str, Enum):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 import redis
 
@@ -19,3 +21,9 @@ def skip_by_redis(request):
     if request.node.get_closest_marker("redis"):
         if not is_redis_available():
             pytest.skip("Redis is not available")
+
+
+@pytest.fixture
+def data_path() -> Path:
+    here = Path(__file__).parent
+    return here / "data"

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,7 +1,10 @@
+from typing import cast
+
 import pytest
 from jinja2 import TemplateSyntaxError
 
 from banks import Prompt
+from banks.types import ContentBlock
 
 
 def test_wrong_tag():
@@ -27,3 +30,53 @@ def test_blocks():
     assert len(content) == 2
     assert content[0].type == "text"  # type: ignore
     assert content[1].type == "image_url"  # type: ignore
+
+
+def test_blocks_newlines():
+    p = Prompt("""{% chat role="system" %}
+Some instructions:
+
+1. Do this.
+2. Then this.
+3. Finally, that.
+{% endchat %}""")
+    messages = p.chat_messages()
+    assert len(messages) == 1
+    assert len(messages[0].content) == 1
+
+
+def test_blocks_complex(data_path):
+    p = Prompt("""
+{% chat role="system" %}
+Given a list of images and text from each image, please answer the question to the best of your ability.
+{% endchat %}
+
+{% chat role="user" %}
+{% for image_path, text in images_and_texts %}
+Here is some text: {{ text }}
+And here is an image:
+{{ image_path | image }}
+{% endfor %}
+{% endchat %}
+    """)
+
+    messages = p.chat_messages(
+        {
+            "images_and_texts": [
+                (str(data_path / "1x1.png"), "This is the first page of the document"),
+                (str(data_path / "1x1.png"), "This is the second page of the document"),
+            ]
+        }
+    )
+    assert len(messages) == 2
+
+    blocks = cast(list[ContentBlock], messages[0].content)
+    assert len(blocks) == 1
+    assert blocks[0].type == "text"
+
+    blocks = cast(list[ContentBlock], messages[1].content)
+    assert len(blocks) == 4
+    assert blocks[0].type == "text"
+    assert blocks[1].type == "image_url"
+    assert blocks[2].type == "text"
+    assert blocks[3].type == "image_url"


### PR DESCRIPTION
Fixes #54 

Extend the regex to account for newlines.