### PR TITLE
feat: implement XML filter for Pydantic/dictionary/deserializable string

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -3,6 +3,7 @@
 - [Create a blog writing prompt](#create-a-blog-writing-prompt)
 - [Create a summarizer prompt](#create-a-summarizer-prompt)
 - [Lemmatize text while processing a template](#lemmatize-text-while-processing-a-template)
+- [Convert a JSON-like object into XML while processing the template](#convert-a-json-like-object-into-xml-while-processing-the-template)
 - [Use a LLM to generate a text while rendering a prompt](#use-a-llm-to-generate-a-text-while-rendering-a-prompt)
 - [Render a prompt template as chat messages](#render-a-prompt-template-as-chat-messages)
 - [Use prompt caching from Anthropic](#use-prompt-caching-from-anthropic)
@@ -133,6 +134,57 @@ the output would be:
 Summarize the following document:
 the cat be run
 Summary:
+```
+
+## Convert a JSON-like object into XML while processing the template
+
+Banks has built-in support for filtering JSON-like objects (Pydantic `BaseModel` subclasses, dictionaries, deserializable strings) and returning an XML string. 
+
+Here is an example of how you can use it:
+
+```python
+from banks import Prompt
+from pydantic import BaseModel
+from typing import Dict
+
+prompt_template = """
+Please extract the contact details from this user:
+
+{{ data | to_xml }}
+
+Contact details:
+"""
+
+class User(BaseModel):
+    username: str
+    account_id: str
+    registered_at: str
+    email: str
+    phone_number: str
+    social_media_accounts: Dict[str, str]
+
+user = User(username="example", account_id="0000", registered_at="10-25-2024", email="example@email.com", phone_number="0123456789", social_media_accounts={"BlueSky": "@example.com"})
+
+p = Prompt(prompt_template)
+print(p.text({"data": user}))
+```
+
+This will output:
+
+```text
+Please extract the contact details from this user:
+
+<user>
+	<username>example</username>
+	<account_id>0000</account_id>
+	<registered_at>10-25-2024</registered_at>
+	<email>example@email.com</email>
+	<phone_number>0123456789</phone_number>
+	<social_media_accounts>{'BlueSky': '@example.com'}</social_media_accounts>
+</user>
+
+
+Contact details:
 ```
 
 ## Use a LLM to generate a text while rendering a prompt

--- a/src/banks/env.py
+++ b/src/banks/env.py
@@ -4,7 +4,7 @@
 from jinja2 import Environment, select_autoescape
 
 from .config import config
-from .filters import audio, cache_control, image, lemmatize, tool
+from .filters import audio, cache_control, image, lemmatize, tool, xml
 
 
 def _add_extensions(_env):
@@ -38,5 +38,6 @@ env.filters["image"] = image
 env.filters["lemmatize"] = lemmatize
 env.filters["tool"] = tool
 env.filters["audio"] = audio
+env.filters["to_xml"] = xml
 
 _add_extensions(env)

--- a/src/banks/filters/__init__.py
+++ b/src/banks/filters/__init__.py
@@ -6,5 +6,6 @@ from .cache_control import cache_control
 from .image import image
 from .lemmatize import lemmatize
 from .tool import tool
+from .xml import xml
 
-__all__ = ("cache_control", "image", "lemmatize", "tool", "audio")
+__all__ = ("cache_control", "image", "lemmatize", "tool", "audio", "xml")

--- a/src/banks/filters/xml.py
+++ b/src/banks/filters/xml.py
@@ -24,11 +24,14 @@ def _prepare_dictionary(value: Union[str, BaseModel, dict[str, Any]]):
         model = value.model_dump()
         root_tag = value.__class__.__name__.lower()
     elif isinstance(value, dict):
+        model = value.copy()
         for k in value.keys():
             if not isinstance(k, str):
-                v = value.pop(k)
-                value[str(k)] = v
-        model = value
+                key = str(k)
+                if isinstance(k, (int, float)):
+                    key = "_" + key
+                v = model.pop(k)
+                model[key.lower()] = v
     else:
         msg = f"Input can only be of type BaseModel, dictionary or deserializable string. Got {type(value)}"
         raise ValueError(msg)

--- a/src/banks/filters/xml.py
+++ b/src/banks/filters/xml.py
@@ -4,11 +4,13 @@ from typing import Dict, Any, Union, Optional
 import xml.etree.ElementTree as ET
 from xml.dom.minidom import parseString
 
+
 def _deserialize(string: str) -> Optional[dict]:
     try:
         return json.loads(string)
     except json.JSONDecodeError:
         return
+
 
 def _prepare_dictionary(value: Union[str, BaseModel, Dict[str, Any]]):
     root_tag = "input"
@@ -28,6 +30,7 @@ def _prepare_dictionary(value: Union[str, BaseModel, Dict[str, Any]]):
     else:
         raise ValueError(f"Input can only be of type BaseModel, dictionary or deserializable string. Got {type(value)}")
     return model, root_tag
+
 
 def xml(value: Union[str, BaseModel, Dict[str, Any]]) -> str:
     """
@@ -49,6 +52,5 @@ def xml(value: Union[str, BaseModel, Dict[str, Any]]) -> str:
     for k, v in model.items():
         sub = ET.SubElement(xml_model, k)
         sub.text = str(v)
-    xml_str = ET.tostring(xml_model, encoding='unicode')
-    return parseString(xml_str).toprettyxml().replace('<?xml version="1.0" ?>\n', '')
-
+    xml_str = ET.tostring(xml_model, encoding="unicode")
+    return parseString(xml_str).toprettyxml().replace('<?xml version="1.0" ?>\n', "")

--- a/src/banks/filters/xml.py
+++ b/src/banks/filters/xml.py
@@ -56,4 +56,4 @@ def xml(value: Union[str, BaseModel, dict[str, Any]]) -> str:
         sub = ET.SubElement(xml_model, k)
         sub.text = str(v)
     xml_str = ET.tostring(xml_model, encoding="unicode")
-    return parseString(xml_str).toprettyxml().replace('<?xml version="1.0" ?>\n', "") # noqa: S318
+    return parseString(xml_str).toprettyxml().replace('<?xml version="1.0" ?>\n', "")  # noqa: S318

--- a/src/banks/filters/xml.py
+++ b/src/banks/filters/xml.py
@@ -1,0 +1,54 @@
+import json
+from pydantic import BaseModel
+from typing import Dict, Any, Union, Optional
+import xml.etree.ElementTree as ET
+from xml.dom.minidom import parseString
+
+def _deserialize(string: str) -> Optional[dict]:
+    try:
+        return json.loads(string)
+    except json.JSONDecodeError:
+        return
+
+def _prepare_dictionary(value: Union[str, BaseModel, Dict[str, Any]]):
+    root_tag = "input"
+    if isinstance(value, str):
+        model: Optional[Dict[str, Any]] = _deserialize(value)
+        if model is None:
+            raise ValueError(f"{value} is not deserializable")
+    elif isinstance(value, BaseModel):
+        model = value.model_dump()
+        root_tag = value.__class__.__name__.lower()
+    elif isinstance(value, dict):
+        for k in value.keys():
+            if not isinstance(k, str):
+                v = value.pop(k)
+                value[str(k)] = v
+        model = value
+    else:
+        raise ValueError(f"Input can only be of type BaseModel, dictionary or deserializable string. Got {type(value)}")
+    return model, root_tag
+
+def xml(value: Union[str, BaseModel, Dict[str, Any]]) -> str:
+    """
+    Convert a Pydatic model, a deserializable string or a dictionary into an XML string.
+
+    Example:
+        ```jinja
+        {{'{"username": "user", "email": "example@email.com"}' | to_xml}}
+        "
+        <input>
+            <username>user</username>
+            <email>example@email.com</email>
+        </input>
+        "
+        ```
+    """
+    model, root_tag = _prepare_dictionary(value)
+    xml_model = ET.Element(root_tag)
+    for k, v in model.items():
+        sub = ET.SubElement(xml_model, k)
+        sub.text = str(v)
+    xml_str = ET.tostring(xml_model, encoding='unicode')
+    return parseString(xml_str).toprettyxml().replace('<?xml version="1.0" ?>\n', '')
+

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -1,8 +1,9 @@
-import pytest
 import xml.etree.ElementTree as ET
+from typing import Any
 from xml.dom.minidom import parseString
+
+import pytest
 from pydantic import BaseModel
-from typing import Tuple, Dict, Any
 
 from banks.filters.xml import xml
 
@@ -15,7 +16,7 @@ def xml_string_from_basemodel() -> str:
     name = ET.SubElement(model, "name")
     name.text = "John Doe"
     xml_str = ET.tostring(model, encoding="unicode")
-    return parseString(xml_str).toprettyxml().replace('<?xml version="1.0" ?>\n', "")
+    return parseString(xml_str).toprettyxml().replace('<?xml version="1.0" ?>\n', "") # noqa: S318
 
 
 @pytest.fixture
@@ -26,11 +27,11 @@ def xml_string_from_other() -> str:
     name = ET.SubElement(model, "name")
     name.text = "John Doe"
     xml_str = ET.tostring(model, encoding="unicode")
-    return parseString(xml_str).toprettyxml().replace('<?xml version="1.0" ?>\n', "")
+    return parseString(xml_str).toprettyxml().replace('<?xml version="1.0" ?>\n', "") # noqa: S318
 
 
 @pytest.fixture
-def starting_value() -> Tuple[BaseModel, Dict[str, Any], str]:
+def starting_value() -> tuple[BaseModel, dict[str, Any], str]:
     class Person(BaseModel):
         age: int
         name: str
@@ -40,7 +41,7 @@ def starting_value() -> Tuple[BaseModel, Dict[str, Any], str]:
 
 
 def test_xml_filter(
-    xml_string_from_basemodel: str, xml_string_from_other: str, starting_value: Tuple[BaseModel, Dict[str, Any], str]
+    xml_string_from_basemodel: str, xml_string_from_other: str, starting_value: tuple[BaseModel, dict[str, Any], str]
 ) -> None:
     model, dictionary, string = starting_value
     assert xml(model) == xml_string_from_basemodel

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -31,6 +31,17 @@ def xml_string_from_other() -> str:
 
 
 @pytest.fixture
+def xml_string_from_edge_case() -> str:
+    model = ET.Element("input")
+    hello = ET.SubElement(model, "_1")
+    hello.text = "hello"
+    world = ET.SubElement(model, "_2.4")
+    world.text = "world"
+    xml_str = ET.tostring(model, encoding="unicode")
+    return parseString(xml_str).toprettyxml().replace('<?xml version="1.0" ?>\n', "")  # noqa: S318
+
+
+@pytest.fixture
 def starting_value() -> tuple[BaseModel, dict[str, Any], str]:
     class Person(BaseModel):
         age: int
@@ -40,10 +51,20 @@ def starting_value() -> tuple[BaseModel, dict[str, Any], str]:
     return p, p.model_dump(), p.model_dump_json()
 
 
+@pytest.fixture
+def dict_edge_case() -> tuple[dict, str]:
+    return {1: "hello", 2.4: "world"}
+
+
 def test_xml_filter(
-    xml_string_from_basemodel: str, xml_string_from_other: str, starting_value: tuple[BaseModel, dict[str, Any], str]
+    xml_string_from_basemodel: str,
+    xml_string_from_other: str,
+    starting_value: tuple[BaseModel, dict[str, Any], str],
+    dict_edge_case: dict,
+    xml_string_from_edge_case: str,
 ) -> None:
     model, dictionary, string = starting_value
     assert xml(model) == xml_string_from_basemodel
     assert xml(dictionary) == xml_string_from_other
     assert xml(string) == xml_string_from_other
+    assert xml(dict_edge_case) == xml_string_from_edge_case

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -1,14 +1,8 @@
-import xml.etree.ElementTree as ET
-from typing import Any
-
 import pytest
-
-try:
-    from defusedxml.minidom import parseString
-    SKIP = False
-except ImportError:
-    SKIP = True
+import xml.etree.ElementTree as ET
+from xml.dom.minidom import parseString
 from pydantic import BaseModel
+from typing import Tuple, Dict, Any
 
 from banks.filters.xml import xml
 
@@ -36,7 +30,7 @@ def xml_string_from_other() -> str:
 
 
 @pytest.fixture
-def starting_value() -> tuple[BaseModel, dict[str, Any], str]:
+def starting_value() -> Tuple[BaseModel, Dict[str, Any], str]:
     class Person(BaseModel):
         age: int
         name: str
@@ -44,12 +38,9 @@ def starting_value() -> tuple[BaseModel, dict[str, Any], str]:
     p = Person(age=30, name="John Doe")
     return p, p.model_dump(), p.model_dump_json()
 
-@pytest.mark.skipif(
-    condition=SKIP,
-    reason="defusedxml is not installed"
-)
+
 def test_xml_filter(
-    xml_string_from_basemodel: str, xml_string_from_other: str, starting_value: tuple[BaseModel, dict[str, Any], str]
+    xml_string_from_basemodel: str, xml_string_from_other: str, starting_value: Tuple[BaseModel, Dict[str, Any], str]
 ) -> None:
     model, dictionary, string = starting_value
     assert xml(model) == xml_string_from_basemodel

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -6,6 +6,7 @@ from typing import Tuple, Dict, Any
 
 from banks.filters.xml import xml
 
+
 @pytest.fixture
 def xml_string_from_basemodel() -> str:
     model = ET.Element("person")
@@ -13,8 +14,9 @@ def xml_string_from_basemodel() -> str:
     age.text = "30"
     name = ET.SubElement(model, "name")
     name.text = "John Doe"
-    xml_str = ET.tostring(model, encoding='unicode')
-    return parseString(xml_str).toprettyxml().replace('<?xml version="1.0" ?>\n', '')
+    xml_str = ET.tostring(model, encoding="unicode")
+    return parseString(xml_str).toprettyxml().replace('<?xml version="1.0" ?>\n', "")
+
 
 @pytest.fixture
 def xml_string_from_other() -> str:
@@ -23,22 +25,24 @@ def xml_string_from_other() -> str:
     age.text = "30"
     name = ET.SubElement(model, "name")
     name.text = "John Doe"
-    xml_str = ET.tostring(model, encoding='unicode')
-    return parseString(xml_str).toprettyxml().replace('<?xml version="1.0" ?>\n', '')
+    xml_str = ET.tostring(model, encoding="unicode")
+    return parseString(xml_str).toprettyxml().replace('<?xml version="1.0" ?>\n', "")
+
 
 @pytest.fixture
 def starting_value() -> Tuple[BaseModel, Dict[str, Any], str]:
     class Person(BaseModel):
         age: int
         name: str
-    
+
     p = Person(age=30, name="John Doe")
     return p, p.model_dump(), p.model_dump_json()
 
-def test_xml_filter(xml_string_from_basemodel: str, xml_string_from_other: str, starting_value: Tuple[BaseModel, Dict[str, Any], str]) -> None:
+
+def test_xml_filter(
+    xml_string_from_basemodel: str, xml_string_from_other: str, starting_value: Tuple[BaseModel, Dict[str, Any], str]
+) -> None:
     model, dictionary, string = starting_value
     assert xml(model) == xml_string_from_basemodel
     assert xml(dictionary) == xml_string_from_other
     assert xml(string) == xml_string_from_other
-
-    

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -1,8 +1,14 @@
-import pytest
 import xml.etree.ElementTree as ET
-from xml.dom.minidom import parseString
+from typing import Any
+
+import pytest
+
+try:
+    from defusedxml.minidom import parseString
+    SKIP = False
+except ImportError:
+    SKIP = True
 from pydantic import BaseModel
-from typing import Tuple, Dict, Any
 
 from banks.filters.xml import xml
 
@@ -30,7 +36,7 @@ def xml_string_from_other() -> str:
 
 
 @pytest.fixture
-def starting_value() -> Tuple[BaseModel, Dict[str, Any], str]:
+def starting_value() -> tuple[BaseModel, dict[str, Any], str]:
     class Person(BaseModel):
         age: int
         name: str
@@ -38,9 +44,12 @@ def starting_value() -> Tuple[BaseModel, Dict[str, Any], str]:
     p = Person(age=30, name="John Doe")
     return p, p.model_dump(), p.model_dump_json()
 
-
+@pytest.mark.skipif(
+    condition=SKIP,
+    reason="defusedxml is not installed"
+)
 def test_xml_filter(
-    xml_string_from_basemodel: str, xml_string_from_other: str, starting_value: Tuple[BaseModel, Dict[str, Any], str]
+    xml_string_from_basemodel: str, xml_string_from_other: str, starting_value: tuple[BaseModel, dict[str, Any], str]
 ) -> None:
     model, dictionary, string = starting_value
     assert xml(model) == xml_string_from_basemodel

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -16,7 +16,7 @@ def xml_string_from_basemodel() -> str:
     name = ET.SubElement(model, "name")
     name.text = "John Doe"
     xml_str = ET.tostring(model, encoding="unicode")
-    return parseString(xml_str).toprettyxml().replace('<?xml version="1.0" ?>\n', "") # noqa: S318
+    return parseString(xml_str).toprettyxml().replace('<?xml version="1.0" ?>\n', "")  # noqa: S318
 
 
 @pytest.fixture
@@ -27,7 +27,7 @@ def xml_string_from_other() -> str:
     name = ET.SubElement(model, "name")
     name.text = "John Doe"
     xml_str = ET.tostring(model, encoding="unicode")
-    return parseString(xml_str).toprettyxml().replace('<?xml version="1.0" ?>\n', "") # noqa: S318
+    return parseString(xml_str).toprettyxml().replace('<?xml version="1.0" ?>\n', "")  # noqa: S318
 
 
 @pytest.fixture

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -1,0 +1,44 @@
+import pytest
+import xml.etree.ElementTree as ET
+from xml.dom.minidom import parseString
+from pydantic import BaseModel
+from typing import Tuple, Dict, Any
+
+from banks.filters.xml import xml
+
+@pytest.fixture
+def xml_string_from_basemodel() -> str:
+    model = ET.Element("person")
+    age = ET.SubElement(model, "age")
+    age.text = "30"
+    name = ET.SubElement(model, "name")
+    name.text = "John Doe"
+    xml_str = ET.tostring(model, encoding='unicode')
+    return parseString(xml_str).toprettyxml().replace('<?xml version="1.0" ?>\n', '')
+
+@pytest.fixture
+def xml_string_from_other() -> str:
+    model = ET.Element("input")
+    age = ET.SubElement(model, "age")
+    age.text = "30"
+    name = ET.SubElement(model, "name")
+    name.text = "John Doe"
+    xml_str = ET.tostring(model, encoding='unicode')
+    return parseString(xml_str).toprettyxml().replace('<?xml version="1.0" ?>\n', '')
+
+@pytest.fixture
+def starting_value() -> Tuple[BaseModel, Dict[str, Any], str]:
+    class Person(BaseModel):
+        age: int
+        name: str
+    
+    p = Person(age=30, name="John Doe")
+    return p, p.model_dump(), p.model_dump_json()
+
+def test_xml_filter(xml_string_from_basemodel: str, xml_string_from_other: str, starting_value: Tuple[BaseModel, Dict[str, Any], str]) -> None:
+    model, dictionary, string = starting_value
+    assert xml(model) == xml_string_from_basemodel
+    assert xml(dictionary) == xml_string_from_other
+    assert xml(string) == xml_string_from_other
+
+    


### PR DESCRIPTION
As per title, I implemented a `to_xml` filter that turns Pydantic models, dictionaries and deserializable strings into XML representations.

Here is an example usage (reported also in the docs):

```python
from banks import Prompt
from pydantic import BaseModel
from typing import Dict

prompt_template = """
Please extract the contact details from this user:

{{ data | to_xml }}

Contact details:
"""

class User(BaseModel):
    username: str
    account_id: str
    registered_at: str
    email: str
    phone_number: str
    social_media_accounts: Dict[str, str]

user = User(username="example", account_id="0000", registered_at="10-25-2024", email="example@email.com", phone_number="0123456789", social_media_accounts={"BlueSky": "@example.com"})

p = Prompt(prompt_template)
print(p.text({"data": user}))
```

This will output:

```text
Please extract the contact details from this user:

<user>
	<username>example</username>
	<account_id>0000</account_id>
	<registered_at>10-25-2024</registered_at>
	<email>example@email.com</email>
	<phone_number>0123456789</phone_number>
	<social_media_accounts>{'BlueSky': '@example.com'}</social_media_accounts>
</user>


Contact details:
```