### PR TITLE
fix: resolve tool callables from an explicit registry instead of importlib

### DIFF
--- a/src/banks/extensions/completion.py
+++ b/src/banks/extensions/completion.py
@@ -1,9 +1,8 @@
 # SPDX-FileCopyrightText: 2023-present Massimiliano Pippi <mpippi@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-import importlib
 import json
-from typing import TYPE_CHECKING, Any, Callable, cast
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, cast
 
 from jinja2 import TemplateSyntaxError, nodes
 from jinja2.ext import Extension
@@ -40,6 +39,14 @@ class CompletionExtension(Extension):
 
     # a set of names that trigger the extension.
     tags = {"completion"}  # noqa
+
+    # Maps tool function name → callable; populated by the `tool` filter at render time.
+    # Resolution never goes through importlib — only callables registered here are invocable.
+    _callable_registry: ClassVar[dict[str, Callable[..., Any]]] = {}
+
+    @classmethod
+    def register_callable(cls, name: str, func: Callable[..., Any]) -> None:
+        cls._callable_registry[name] = func
 
     def parse(self, parser):
         # We get the line number of the first token for error reporting
@@ -87,15 +94,16 @@ class CompletionExtension(Extension):
             The callable function
 
         Raises:
-            ValueError: If the function is not found in available tools
+            ValueError: If the function is not found in available tools or not registered
         """
-        for tool in tools:
-            if tool.function.name == tool_call.function.name:
-                module_name, func_name = tool.import_path.rsplit(".", maxsplit=1)
-                module = importlib.import_module(module_name)
-                return getattr(module, func_name)
-        msg = f"Function {tool_call.function.name} not found in available tools"
-        raise ValueError(msg)
+        name = tool_call.function.name
+        if not any(t.function.name == name for t in tools):
+            msg = f"Function {name} not found in available tools"
+            raise ValueError(msg)
+        if name not in self._callable_registry:
+            msg = f"Function {name!r} is not registered"
+            raise ValueError(msg)
+        return self._callable_registry[name]
 
     def _do_completion(self, model_name, caller):
         """
@@ -109,7 +117,7 @@ class CompletionExtension(Extension):
 
         messages, tools = self._body_to_messages(caller())
         message_dicts = [m.model_dump() for m in messages]
-        tool_dicts = [t.model_dump() for t in tools] or None
+        tool_dicts = [t.model_dump(exclude={"import_path"}) for t in tools] or None
 
         response = cast(ModelResponse, completion(model=model_name, messages=message_dicts, tools=tool_dicts))
         choices = cast(list[Choices], response.choices)
@@ -149,7 +157,7 @@ class CompletionExtension(Extension):
 
         messages, tools = self._body_to_messages(caller())
         message_dicts = [m.model_dump() for m in messages]
-        tool_dicts = [t.model_dump() for t in tools] or None
+        tool_dicts = [t.model_dump(exclude={"import_path"}) for t in tools] or None
 
         response = cast(ModelResponse, await acompletion(model=model_name, messages=message_dicts, tools=tool_dicts))
         choices = cast(list[Choices], response.choices)

--- a/src/banks/filters/tool.py
+++ b/src/banks/filters/tool.py
@@ -12,5 +12,8 @@ def tool(function: Callable) -> str:
     Important:
         This filter only works when used within a `{% completion %}` block.
     """
+    from banks.extensions.completion import CompletionExtension  # lazy to avoid circular import
+
     t = Tool.from_callable(function)
+    CompletionExtension.register_callable(function.__name__, function)
     return t.model_dump_json() + "\n"

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -10,6 +10,13 @@ from banks.extensions.completion import CompletionExtension
 from banks.types import ChatMessage, Tool
 
 
+@pytest.fixture(autouse=True)
+def clear_callable_registry():
+    CompletionExtension._callable_registry.clear()
+    yield
+    CompletionExtension._callable_registry.clear()
+
+
 @pytest.fixture
 def ext():
     return CompletionExtension(environment=Environment())
@@ -165,7 +172,7 @@ async def test__do_completion_async_with_tools(ext, mocked_choices_with_tools, t
         await ext._do_completion_async("test-model", lambda: '{"role":"user", "content":"hello"}')
         calls = mocked_completion.call_args_list
         assert len(calls) == 2  # complete query, complete with tool results
-        assert calls[0].kwargs["tools"] == [t.model_dump() for t in tools]
+        assert calls[0].kwargs["tools"] == [t.model_dump(exclude={"import_path"}) for t in tools]
         for m in calls[1].kwargs["messages"]:
             if type(m) is ChatMessage:
                 assert m.role == "tool"
@@ -202,6 +209,7 @@ async def test__do_completion_async_no_prompt_no_tools(ext, mocked_choices_no_to
 
 
 def test__get_tool_callable(ext, tools):
+    CompletionExtension.register_callable("getenv", getenv)
     tool_call = mock.MagicMock()
 
     tool_call.function.name = "getenv"
@@ -210,3 +218,34 @@ def test__get_tool_callable(ext, tools):
     tool_call.function.name = "another_func"
     with pytest.raises(ValueError, match="Function another_func not found in available tools"):
         ext._get_tool_callable(tools, tool_call)
+
+
+def test__get_tool_callable_rejects_unregistered(ext, tools):
+    # Even if the tool name matches, an unregistered callable cannot be invoked.
+    tool_call = mock.MagicMock()
+    tool_call.function.name = "getenv"
+    with pytest.raises(ValueError, match="'getenv' is not registered"):
+        ext._get_tool_callable(tools, tool_call)
+
+
+def test__get_tool_callable_rejects_malicious_import_path(ext):
+    """An attacker-injected import_path must never resolve via importlib."""
+    malicious_tool = Tool.model_validate(
+        {
+            "type": "function",
+            "function": {
+                "name": "rce",
+                "description": "rce",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"command": {"type": "string", "description": "shell"}},
+                    "required": ["command"],
+                },
+            },
+            "import_path": "os.system",
+        }
+    )
+    tool_call = mock.MagicMock()
+    tool_call.function.name = "rce"
+    with pytest.raises(ValueError):
+        ext._get_tool_callable([malicious_tool], tool_call)


### PR DESCRIPTION
## Summary

- `CompletionExtension` now maintains a `_callable_registry` (name → callable) populated by the `tool` filter at template render time
- `_get_tool_callable` resolves callables exclusively from this registry; `importlib.import_module` is no longer used in the dispatch path
- `Tool.import_path` is excluded from the payload sent to the LLM — the field is an internal Python concern and has no meaning for the model

## Test plan

- [ ] `test__get_tool_callable` — happy path still passes with explicit registration
- [ ] `test__get_tool_callable_rejects_unregistered` — a tool declared in the template but not in the registry raises `ValueError`
- [ ] `test__get_tool_callable_rejects_malicious_import_path` — a `Tool` with an arbitrary `import_path` cannot be resolved
- [ ] All existing completion/tool tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)