### PR TITLE
fix: restrict media filter file paths to the current working directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,7 @@ hatch run test tests/test_foo.py  # Run specific test file
 - Environment variable-based configuration with `BANKS_` prefix
 - `BANKS_ASYNC_ENABLED`: Enable async template rendering (must be set before import)
 - `BANKS_USER_DATA_PATH`: Custom user data directory
+- `BANKS_MEDIA_ROOT`: Restrict media filter file reads to this directory (defaults to CWD)
 
 ## Key Development Patterns
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,6 +74,16 @@ p = Prompt("Write a blog post about {{ topic }}.")
 result = p.text({"topic": user_input})
 ```
 
+### Media filters and file access
+
+The `image`, `audio`, `video`, and `document` filters can read local files when given a file path. To prevent untrusted input from reading arbitrary files, these filters only open paths that resolve within an allowed root directory. By default the root is the current working directory; set the `BANKS_MEDIA_ROOT` environment variable to restrict reads to a specific directory:
+
+```bash
+BANKS_MEDIA_ROOT=/var/myapp/assets uvicorn app:app
+```
+
+Any path that resolves outside the configured root raises a `ValueError`. Passing bytes or a URL instead of a file path is always allowed and is the safest option when the value comes from user input.
+
 ## License
 
 `banks` is distributed under the terms of the [MIT](https://spdx.org/licenses/MIT.html) license.

--- a/src/banks/config.py
+++ b/src/banks/config.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 import os
+import types as _types
+import typing
 from pathlib import Path
 from typing import Any
 
@@ -10,9 +12,24 @@ from platformdirs import user_data_path
 from .utils import strtobool
 
 
+def _unwrap_optional(t: Any) -> Any:
+    """Return the inner type of Optional[X] / X | None, or t unchanged."""
+    origin = getattr(t, "__origin__", None)
+    if origin is typing.Union:
+        args = [a for a in t.__args__ if a is not type(None)]
+        if len(args) == 1:
+            return args[0]
+    if isinstance(t, _types.UnionType):
+        args = [a for a in t.__args__ if a is not type(None)]
+        if len(args) == 1:
+            return args[0]
+    return t
+
+
 class _BanksConfig:
     ASYNC_ENABLED: bool = False
     USER_DATA_PATH: Path = user_data_path("banks")
+    MEDIA_ROOT: Path | None = None
 
     def __init__(self, env_var_prefix: str = "BANKS_"):
         self._env_var_prefix = env_var_prefix
@@ -29,7 +46,7 @@ class _BanksConfig:
 
         # Convert string from env var to the actual type
         annotations = getattr(type(self), "__annotations__", {})
-        t = annotations.get(name, type(original_value))
+        t = _unwrap_optional(annotations.get(name, type(original_value)))
         if t is bool:
             return strtobool(read_value)
         if t is Any:

--- a/src/banks/config.py
+++ b/src/banks/config.py
@@ -16,11 +16,11 @@ def _unwrap_optional(t: Any) -> Any:
     """Return the inner type of Optional[X] / X | None, or t unchanged."""
     origin = getattr(t, "__origin__", None)
     if origin is typing.Union:
-        args = [a for a in t.__args__ if a is not type(None)]
+        args = [a for a in t.__args__ if a is not None.__class__]
         if len(args) == 1:
             return args[0]
     if isinstance(t, _types.UnionType):
-        args = [a for a in t.__args__ if a is not type(None)]
+        args = [a for a in t.__args__ if a is not None.__class__]
         if len(args) == 1:
             return args[0]
     return t

--- a/src/banks/types.py
+++ b/src/banks/types.py
@@ -37,7 +37,9 @@ def _safe_resolve_path(file_path: Path) -> Path:
     try:
         resolved.relative_to(root)
     except ValueError:
-        msg = f"Access denied: '{file_path}' resolves outside the allowed media root (set BANKS_MEDIA_ROOT to configure)"
+        msg = (
+            f"Access denied: '{file_path}' resolves outside the allowed media root (set BANKS_MEDIA_ROOT to configure)"
+        )
         raise ValueError(msg) from None
     return resolved
 

--- a/src/banks/types.py
+++ b/src/banks/types.py
@@ -24,17 +24,21 @@ CONTENT_BLOCK_REGEX = re.compile(r"(<content_block>\{.*?\}<\/content_block>)|([^
 
 
 def _safe_resolve_path(file_path: Path) -> Path:
-    """Resolve a media file path and ensure it stays within the current working directory.
+    """Resolve a media file path and ensure it stays within the allowed root directory.
 
-    Raises ValueError for paths that escape the CWD (absolute paths to sensitive locations,
-    path traversal via '..', or symlinks pointing outside CWD).
+    The allowed root is taken from the BANKS_MEDIA_ROOT environment variable when set;
+    otherwise it falls back to the current working directory.
+
+    Raises ValueError for paths that resolve outside the allowed root (absolute paths
+    to sensitive locations, path traversal via '..', or symlinks pointing outside).
     """
-    cwd = Path(os.getcwd()).resolve()
-    resolved = (cwd / file_path).resolve() if not file_path.is_absolute() else file_path.resolve()
+    root_env = os.environ.get("BANKS_MEDIA_ROOT")
+    root = Path(root_env).resolve() if root_env else Path(os.getcwd()).resolve()
+    resolved = (root / file_path).resolve() if not file_path.is_absolute() else file_path.resolve()
     try:
-        resolved.relative_to(cwd)
+        resolved.relative_to(root)
     except ValueError:
-        msg = f"Access denied: '{file_path}' resolves outside the current working directory"
+        msg = f"Access denied: '{file_path}' resolves outside the allowed media root (set BANKS_MEDIA_ROOT to configure)"
         raise ValueError(msg) from None
     return resolved
 

--- a/src/banks/types.py
+++ b/src/banks/types.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import base64
+import os
 import re
 from base64 import b64decode, b64encode
 from binascii import Error as BinasciiError
@@ -20,6 +21,22 @@ from .utils import parse_params_from_docstring, python_type_to_jsonschema
 
 # pylint: disable=invalid-name
 CONTENT_BLOCK_REGEX = re.compile(r"(<content_block>\{.*?\}<\/content_block>)|([^<](?:(?!<content_block>)[\s\S])*)")
+
+
+def _safe_resolve_path(file_path: Path) -> Path:
+    """Resolve a media file path and ensure it stays within the current working directory.
+
+    Raises ValueError for paths that escape the CWD (absolute paths to sensitive locations,
+    path traversal via '..', or symlinks pointing outside CWD).
+    """
+    cwd = Path(os.getcwd()).resolve()
+    resolved = (cwd / file_path).resolve() if not file_path.is_absolute() else file_path.resolve()
+    try:
+        resolved.relative_to(cwd)
+    except ValueError:
+        msg = f"Access denied: '{file_path}' resolves outside the current working directory"
+        raise ValueError(msg) from None
+    return resolved
 
 
 def resolve_binary(bytes_str: bytes, *, as_base64: bool = True) -> bytes:
@@ -76,7 +93,7 @@ class ImageUrl(BaseModel):
 
     @classmethod
     def from_path(cls, file_path: Path) -> Self:
-        with open(file_path, "rb") as image_file:
+        with open(_safe_resolve_path(file_path), "rb") as image_file:
             raw_bytes = image_file.read()
             mimetype = cls._mimetype_from_bytes(raw_bytes)
             return cls.from_base64(mimetype, base64.b64encode(raw_bytes).decode("utf-8"))
@@ -110,7 +127,8 @@ class InputAudio(BaseModel):
 
     @classmethod
     def from_path(cls, file_path: Path) -> Self:
-        with open(file_path, "rb") as audio_file:
+        safe_path = _safe_resolve_path(file_path)
+        with open(safe_path, "rb") as audio_file:
             encoded_str = base64.b64encode(audio_file.read()).decode("utf-8")
             file_format = cast(AudioFormat, file_path.suffix[1:])
             return cls(data=encoded_str, format=file_format)
@@ -150,7 +168,8 @@ class InputVideo(BaseModel):
 
     @classmethod
     def from_path(cls, file_path: Path) -> Self:
-        with open(file_path, "rb") as video_file:
+        safe_path = _safe_resolve_path(file_path)
+        with open(safe_path, "rb") as video_file:
             encoded_str = base64.b64encode(video_file.read()).decode("utf-8")
             file_format = cast(VideoFormat, file_path.suffix[1:])
             return cls(data=encoded_str, format=file_format)
@@ -190,7 +209,8 @@ class InputDocument(BaseModel):
 
     @classmethod
     def from_path(cls, file_path: Path) -> Self:
-        with open(file_path, "rb") as document_file:
+        safe_path = _safe_resolve_path(file_path)
+        with open(safe_path, "rb") as document_file:
             encoded_str = base64.b64encode(document_file.read()).decode("utf-8")
             file_format = cast(DocumentFormat, file_path.suffix[1:])
             return cls(data=encoded_str, format=file_format)

--- a/src/banks/types.py
+++ b/src/banks/types.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import base64
-import os
 import re
 from base64 import b64decode, b64encode
 from binascii import Error as BinasciiError
@@ -17,6 +16,7 @@ import filetype  # type: ignore[import-untyped]
 from pydantic import BaseModel
 from typing_extensions import Self
 
+from .config import config
 from .utils import parse_params_from_docstring, python_type_to_jsonschema
 
 # pylint: disable=invalid-name
@@ -32,8 +32,7 @@ def _safe_resolve_path(file_path: Path) -> Path:
     Raises ValueError for paths that resolve outside the allowed root (absolute paths
     to sensitive locations, path traversal via '..', or symlinks pointing outside).
     """
-    root_env = os.environ.get("BANKS_MEDIA_ROOT")
-    root = Path(root_env).resolve() if root_env else Path(os.getcwd()).resolve()
+    root = config.MEDIA_ROOT.resolve() if config.MEDIA_ROOT else Path.cwd().resolve()
     resolved = (root / file_path).resolve() if not file_path.is_absolute() else file_path.resolve()
     try:
         resolved.relative_to(root)

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -37,10 +37,10 @@ def test_image_with_url():
     assert content_block["image_url"]["url"] == url
 
 
-def test_image_with_file_path(tmp_path):
+def test_image_with_file_path(tmp_path, monkeypatch):
     """Test image filter with a file path input"""
-    # Create a temporary test image file
-    test_image = tmp_path / "test_image.jpg"
+    monkeypatch.chdir(tmp_path)
+    test_image = Path("test_image.jpg")
     test_content = b"fake image content"
     test_image.write_bytes(test_content)
 
@@ -56,6 +56,12 @@ def test_image_with_file_path(tmp_path):
 
     assert content_block["type"] == "image_url"
     assert content_block["image_url"]["url"].startswith("data:image/jpeg;base64,")
+
+
+def test_image_path_traversal_blocked():
+    """Test that path traversal is blocked"""
+    with pytest.raises(ValueError, match="Access denied"):
+        image("/etc/hosts")
 
 
 def test_image_base64(tmp_path):

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -59,9 +59,11 @@ def test_image_with_file_path(tmp_path, monkeypatch):
 
 
 def test_image_path_traversal_blocked():
-    """Test that path traversal is blocked"""
+    """Test that absolute paths and traversal sequences outside CWD are blocked"""
     with pytest.raises(ValueError, match="Access denied"):
         image("/etc/hosts")
+    with pytest.raises(ValueError, match="Access denied"):
+        image("../../../etc/hosts")
 
 
 def test_image_base64(tmp_path):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -17,10 +17,10 @@ def test_image_url_from_base64():
     assert image_url.url == expected_url
 
 
-def test_image_url_from_path(tmp_path):
+def test_image_url_from_path(tmp_path, monkeypatch):
     """Test creating ImageUrl from a file path"""
-    # Create a temporary test image file
-    test_image = tmp_path / "test_image.jpg"
+    monkeypatch.chdir(tmp_path)
+    test_image = Path("test_image.jpg")
     test_content = b"fake image content"
     test_image.write_bytes(test_content)
 
@@ -41,10 +41,16 @@ def test_image_url_from_path_nonexistent():
         ImageUrl.from_path(Path("nonexistent.jpg"))
 
 
-def test_input_audio_from_path(tmp_path):
+def test_image_url_from_path_outside_cwd():
+    """Test that paths outside CWD are rejected"""
+    with pytest.raises(ValueError, match="Access denied"):
+        ImageUrl.from_path(Path("/etc/hosts"))
+
+
+def test_input_audio_from_path(tmp_path, monkeypatch):
     """Test creating InputAudio from a file path"""
-    # Create a temporary test image file
-    test_audio = tmp_path / "test_audio.wav"
+    monkeypatch.chdir(tmp_path)
+    test_audio = Path("test_audio.wav")
     test_content = b"fake audio data"
     test_audio.write_bytes(test_content)
 
@@ -59,3 +65,9 @@ def test_input_audio_from_path_nonexistent():
     """Test creating ImageUrl from a nonexistent file path"""
     with pytest.raises(FileNotFoundError):
         InputAudio.from_path(Path("nonexistent.wav"))
+
+
+def test_input_audio_from_path_outside_cwd():
+    """Test that paths outside CWD are rejected"""
+    with pytest.raises(ValueError, match="Access denied"):
+        InputAudio.from_path(Path("/etc/hosts"))

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -47,6 +47,23 @@ def test_image_url_from_path_outside_cwd():
         ImageUrl.from_path(Path("/etc/hosts"))
 
 
+def test_image_url_from_path_with_media_root(tmp_path, monkeypatch):
+    """Test that BANKS_MEDIA_ROOT is used when set"""
+    monkeypatch.setenv("BANKS_MEDIA_ROOT", str(tmp_path))
+    test_image = tmp_path / "test_image.jpg"
+    test_image.write_bytes(b"fake image content")
+
+    image_url = ImageUrl.from_path(test_image)
+    assert image_url.url.startswith("data:image/jpeg;base64,")
+
+
+def test_image_url_from_path_outside_media_root(tmp_path, monkeypatch):
+    """Test that paths outside BANKS_MEDIA_ROOT are rejected"""
+    monkeypatch.setenv("BANKS_MEDIA_ROOT", str(tmp_path))
+    with pytest.raises(ValueError, match="Access denied"):
+        ImageUrl.from_path(Path("/etc/hosts"))
+
+
 def test_input_audio_from_path(tmp_path, monkeypatch):
     """Test creating InputAudio from a file path"""
     monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
## Summary

- Added `_safe_resolve_path()` in `types.py` that canonicalizes a path and rejects anything resolving outside the allowed root
- Allowed root is read from `BANKS_MEDIA_ROOT` env var; falls back to CWD when unset
- Applied to all four `from_path()` methods: `ImageUrl`, `InputAudio`, `InputVideo`, `InputDocument`
- Updated tests to use `monkeypatch.chdir` / `monkeypatch.setenv` and added explicit rejection tests

## Behaviour

| Scenario | Result |
|---|---|
| Relative path within root | ✅ allowed |
| Absolute path within `BANKS_MEDIA_ROOT` | ✅ allowed |
| Absolute path outside root (`/etc/hosts`) | ❌ `ValueError: Access denied` |
| Path traversal (`../../../etc/hosts`) | ❌ `ValueError: Access denied` |

Set `BANKS_MEDIA_ROOT=/var/myapp/assets` in the environment to restrict reads to that directory. If unset, the current working directory is used as the root.

## Test plan

- [ ] `pytest tests/test_types.py tests/test_image.py tests/test_audio.py tests/test_video.py tests/test_document.py` — all pass
- [ ] Verify `ValueError: Access denied` is raised for `/etc/hosts` and `../../../etc/hosts`
- [ ] Verify `BANKS_MEDIA_ROOT` is respected when set

🤖 Generated with [Claude Code](https://claude.com/claude-code)