### PR TITLE
fix: validate prompt paths in DirectoryPromptRegistry

### DIFF
--- a/src/banks/registries/directory.py
+++ b/src/banks/registries/directory.py
@@ -32,6 +32,13 @@ def _resolve_prompt_file(registry_root: Path, name: str, version: str) -> Path:
     if Path(version).is_absolute():
         msg = f"Invalid prompt version: {version!r}"
         raise InvalidPromptError(msg)
+    if "/" in version or "\\" in version or version in (".", ".."):
+        msg = f"Invalid prompt version: {version!r}"
+        raise InvalidPromptError(msg)
+    for part in Path(name).parts:
+        if part in (".", ".."):
+            msg = f"Invalid prompt name: {name!r}"
+            raise InvalidPromptError(msg)
 
     root = registry_root.resolve()
     candidate = (registry_root / f"{name}.{version}.jinja").resolve()

--- a/src/banks/registries/directory.py
+++ b/src/banks/registries/directory.py
@@ -24,6 +24,23 @@ from banks.prompt import DEFAULT_VERSION, PromptModel
 DEFAULT_INDEX_NAME = "index.json"
 
 
+def _resolve_prompt_file(registry_root: Path, name: str, version: str) -> Path:
+    """Resolve the on-disk path for a prompt file, ensuring it stays within ``registry_root``."""
+    if Path(name).is_absolute():
+        msg = f"Invalid prompt name: {name!r}"
+        raise InvalidPromptError(msg)
+    if Path(version).is_absolute():
+        msg = f"Invalid prompt version: {version!r}"
+        raise InvalidPromptError(msg)
+
+    root = registry_root.resolve()
+    candidate = (registry_root / f"{name}.{version}.jinja").resolve()
+    if not candidate.is_relative_to(root):
+        msg = f"Prompt path escapes registry root: {candidate}"
+        raise InvalidPromptError(msg)
+    return candidate
+
+
 class PromptFile(PromptModel):
     """Model representing a prompt file stored on disk."""
 
@@ -41,7 +58,8 @@ class PromptFile(PromptModel):
         Returns:
             A new PromptFile instance
         """
-        prompt_file = path / f"{prompt.name}.{prompt.version}.jinja"
+        version = prompt.version or DEFAULT_VERSION
+        prompt_file = _resolve_prompt_file(path, prompt.name, version)
         prompt_file.write_text(prompt.raw)
         return cls(
             text=prompt.raw, name=prompt.name, version=prompt.version, metadata=prompt.metadata, path=prompt_file
@@ -137,8 +155,8 @@ class DirectoryPromptRegistry:
         self._index = PromptFileIndex.model_validate_json(self._index_path.read_text())
         # Reconstruct the file paths since they're excluded from serialization
         for pf in self._index.files:
-            if pf.path is None:
-                pf.path = self._path / f"{pf.name}.{pf.version}.jinja"
+            version = pf.version or DEFAULT_VERSION
+            pf.path = _resolve_prompt_file(self._path, pf.name, version)
 
     def _save(self):
         """Save the prompt index to disk."""

--- a/tests/test_directory_registry.py
+++ b/tests/test_directory_registry.py
@@ -97,3 +97,43 @@ def test_update_meta(registry: DirectoryPromptRegistry):
     # reload prompt
     p = registry.get(name="new", version="3")
     assert p.metadata == {"accuracy": 94.3, "created_at": created_time}
+
+
+@pytest.mark.parametrize(
+    ("name", "version"),
+    [
+        ("../victim/pwned", "0"),
+        ("/etc/passwd", "0"),
+        ("okay", "../../../evil"),
+    ],
+)
+def test_set_rejects_path_escape(tmp_path: Path, name: str, version: str):
+    registry_dir = tmp_path / "registry"
+    registry_dir.mkdir()
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    reg = DirectoryPromptRegistry(registry_dir, force_reindex=True)
+
+    with pytest.raises(InvalidPromptError):
+        reg.set(prompt=Prompt("pwn", name=name, version=version))
+
+    assert list(victim.iterdir()) == []
+    assert not (tmp_path / "evil.jinja").exists()
+
+
+def test_set_allows_nested_name(tmp_path: Path):
+    registry_dir = tmp_path / "registry"
+    registry_dir.mkdir()
+    reg = DirectoryPromptRegistry(registry_dir, force_reindex=True)
+    (registry_dir / "team").mkdir()
+
+    reg.set(prompt=Prompt("nested prompt", name="team/nested", version="1"))
+    assert (registry_dir / "team" / "nested.1.jinja").read_text() == "nested prompt"
+
+
+def test_load_rejects_poisoned_index(tmp_path: Path):
+    (tmp_path / DEFAULT_INDEX_NAME).write_text(
+        '{"files":[{"text":"pwn","name":"../evil","version":"0","metadata":{}}]}'
+    )
+    with pytest.raises(InvalidPromptError):
+        DirectoryPromptRegistry(tmp_path)

--- a/tests/test_directory_registry.py
+++ b/tests/test_directory_registry.py
@@ -105,6 +105,7 @@ def test_update_meta(registry: DirectoryPromptRegistry):
         ("../victim/pwned", "0"),
         ("/etc/passwd", "0"),
         ("okay", "../../../evil"),
+        ("team/../nested", "0"),
     ],
 )
 def test_set_rejects_path_escape(tmp_path: Path, name: str, version: str):
@@ -119,6 +120,20 @@ def test_set_rejects_path_escape(tmp_path: Path, name: str, version: str):
 
     assert list(victim.iterdir()) == []
     assert not (tmp_path / "evil.jinja").exists()
+
+
+def test_set_rejects_dot_segment_overwrite_bypass(tmp_path: Path):
+    registry_dir = tmp_path / "registry"
+    registry_dir.mkdir()
+    reg = DirectoryPromptRegistry(registry_dir, force_reindex=True)
+    (registry_dir / "team").mkdir()
+
+    reg.set(prompt=Prompt("original", name="team/nested", version="1"))
+
+    with pytest.raises(InvalidPromptError):
+        reg.set(prompt=Prompt("bypass", name="team/../nested", version="1"))
+
+    assert (registry_dir / "team" / "nested.1.jinja").read_text() == "original"
 
 
 def test_set_allows_nested_name(tmp_path: Path):


### PR DESCRIPTION
## Summary
- Add `_resolve_prompt_file` to ensure prompt file paths stay within the registry root when writing or loading prompts
- Reject absolute prompt names/versions and path-traversal sequences in `set()` and when reconstructing paths from a saved index
- Add tests for path-escape rejection, nested names under the registry, and poisoned index entries

## Test plan
- [x] `hatch run test tests/test_directory_registry.py` (14 passed)


Made with [Cursor](https://cursor.com)